### PR TITLE
STL containers support for Templates

### DIFF
--- a/src/inja.hpp
+++ b/src/inja.hpp
@@ -228,6 +228,7 @@ enum class ElementNotation {
 
 struct Parsed {
 	enum class Type {
+		None,
 		Comment,
 		Condition,
 		ConditionBranch,
@@ -298,6 +299,7 @@ struct Parsed {
 		std::string inner;
 		std::vector<std::shared_ptr<Element>> children;
 
+		explicit Element(): Element(Type::None, "") { }
 		explicit Element(const Type type): Element(type, "") { }
 		explicit Element(const Type type, const std::string& inner): type(type), inner(inner), children({}) { }
 	};
@@ -353,9 +355,12 @@ struct Parsed {
 
 class Template {
 public:
-	const Parsed::Element parsed_template;
+	Parsed::Element parsed_template() { return _parsed_template; };
 
-	explicit Template(const Parsed::Element& parsed_template): parsed_template(parsed_template) { }
+	explicit Template (): _parsed_template(Parsed::Element()) {}
+	explicit Template(const Parsed::Element& parsed_template): _parsed_template(parsed_template) { }
+private:
+	Parsed::Element _parsed_template;
 };
 
 
@@ -517,7 +522,7 @@ public:
 
 	std::string render(Template temp, const json& data) {
 		std::string result = "";
-		for (auto element: temp.parsed_template.children) {
+		for (auto element: temp.parsed_template().children) {
 			switch (element->type) {
 				case Parsed::Type::String: {
 					auto element_string = std::static_pointer_cast<Parsed::ElementString>(element);
@@ -844,7 +849,7 @@ public:
 						case Parsed::Statement::Include: {
 							std::string included_filename = path + match_statement.str(1);
 							Template included_template = parse_template(included_filename);
-							for (auto element : included_template.parsed_template.children) {
+							for (auto element : included_template.parsed_template().children) {
 								result.emplace_back(element);
 							}
 							break;

--- a/src/inja.hpp
+++ b/src/inja.hpp
@@ -355,7 +355,7 @@ struct Parsed {
 
 class Template {
 public:
-	Parsed::Element parsed_template() { return _parsed_template; };
+	const Parsed::Element parsed_template() { return _parsed_template; };
 
 	explicit Template (): _parsed_template(Parsed::Element()) {}
 	explicit Template(const Parsed::Element& parsed_template): _parsed_template(parsed_template) { }


### PR DESCRIPTION
My use case was the following:

  ```
std::unordered_map<std::string, inja::Template> _templateMap;

  .....
 
  for (auto filename : TEMPLATE_LIST) {
    auto path = TEMPLATE_ROOT + filename;
    _templateMap[filename] = _env.parse_template(path);
  }
```

Idea is to cache templates in the std::map and use them multiple times. I needed to add default constructors and Type::None (which is optional). I believe it would be nice to have this feature even if you don't use my implementation.
