### PR TITLE
Check for path in filename passed to include Statement

### DIFF
--- a/src/inja.hpp
+++ b/src/inja.hpp
@@ -864,7 +864,7 @@ public:
 								included_template = included_templates[template_name];
 							} else {
                                 std::string template_file = template_name;
-                                if ( std::regex_search(template_file, std::regex("^(\./|[:alpha:]:")) )   // Relative or absolute file path
+                                if ( not std::regex_search(template_file, std::regex("^(\\.|/|[:alpha:]:)")) )   // Relative or absolute file path
                                 {
                                     template_file = path + template_file;
                                 }

--- a/src/inja.hpp
+++ b/src/inja.hpp
@@ -863,7 +863,12 @@ public:
 							if (included_templates.find( template_name ) != included_templates.end()) {
 								included_template = included_templates[template_name];
 							} else {
-								included_template = parse_template(path + template_name);
+                                std::string template_file = template_name;
+                                if ( std::regex_search(template_file, std::regex("^(\./|[:alpha:]:")) )   // Relative or absolute file path
+                                {
+                                    template_file = path + template_file;
+                                }
+								included_template = parse_template(template_file);
 							}
 
 							auto children = included_template.parsed_template().children;

--- a/src/inja.hpp
+++ b/src/inja.hpp
@@ -863,11 +863,11 @@ public:
 							if (included_templates.find( template_name ) != included_templates.end()) {
 								included_template = included_templates[template_name];
 							} else {
-                                std::string template_file = template_name;
-                                if ( not std::regex_search(template_file, std::regex("^(\\.|/|[:alpha:]:)")) )   // Relative or absolute file path
-                                {
-                                    template_file = path + template_file;
-                                }
+								std::string template_file = template_name;
+								if ( not std::regex_search(template_file, std::regex("^(\\.|/|[:alpha:]:)")) )   // Relative or absolute file path
+								{
+									template_file = path + template_file;
+								}
 								included_template = parse_template(template_file);
 							}
 


### PR DESCRIPTION
If the file given in an `include` statement includes a path component then use that path rather than the path of the including template.