### PR TITLE
Fix the std::transform bug

### DIFF
--- a/src/inja.hpp
+++ b/src/inja.hpp
@@ -396,12 +396,12 @@ public:
 		switch (element.function) {
 			case Parsed::Function::Upper: {
 				std::string str = eval_expression<std::string>(element.args[0], data);
-				std::transform(str.begin(), str.end(), str.begin(), toupper);
+				std::transform(str.begin(), str.end(), str.begin(), ::toupper);
 				return str;
 			}
 			case Parsed::Function::Lower: {
 				std::string str = eval_expression<std::string>(element.args[0], data);
-				std::transform(str.begin(), str.end(), str.begin(), tolower);
+				std::transform(str.begin(), str.end(), str.begin(), ::tolower);
 				return str;
 			}
 			case Parsed::Function::Range: {


### PR DESCRIPTION
https://stackoverflow.com/questions/16792456/no-matching-function-for-call-to-transform

This is a fix for using toupper and tolower with std::transform. Otherwise it can give an error because the function cannot be resolved properly.