### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 add_custom_command(
   TARGET ${UNITTEST_TARGET_NAME} POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
-  ${CMAKE_SOURCE_DIR}/test/data
+  ${CMAKE_CURRENT_SOURCE_DIR}/test/data
   ${CMAKE_CURRENT_BINARY_DIR}/data
 )
 ##


### PR DESCRIPTION
Your cmake file path was wrongly set. This will create build error when using inja as a sub-project.