### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 add_custom_command(
   TARGET ${UNITTEST_TARGET_NAME} POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
-  ${CMAKE_CURRENT_SOURCE_DIR}/test/data
+  ${CMAKE_CURRENT_SOURCE_DIR}/data
   ${CMAKE_CURRENT_BINARY_DIR}/data
 )
 ##


### PR DESCRIPTION
Sorry, the fix I proposed was not exactly the same I used to fix my build.

To be more specific, the ${CMAKE_CURRENT_SOURCE_DIR} variable includes the test sub-directory. So I removed it in this patch.