### PR TITLE
Fix for issue #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ data["name"] = "world";
 
 render("Hello {{ name }}!", data); // Returns std::string "Hello world!"
 render_to(std::cout, "Hello {{ name }}!", data); // Prints "Hello world!"
+```
 
-// For more advanced usage, an environment is recommended
+For more advanced usage, an environment is recommended.
+```c++
 Environment env;
 
 // Render a string with json data

--- a/include/inja/config.hpp
+++ b/include/inja/config.hpp
@@ -24,7 +24,10 @@ struct LexerConfig {
   std::string open_chars {"#{"};
 
   void update_open_chars() {
-    open_chars = "\n";
+    open_chars = "";
+    if (open_chars.find(line_statement[0]) == std::string::npos) {
+      open_chars += line_statement[0];
+    }
     if (open_chars.find(statement_open[0]) == std::string::npos) {
       open_chars += statement_open[0];
     }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1371,7 +1371,10 @@ struct LexerConfig {
   std::string open_chars {"#{"};
 
   void update_open_chars() {
-    open_chars = "\n";
+    open_chars = "";
+    if (open_chars.find(line_statement[0]) == std::string::npos) {
+      open_chars += line_statement[0];
+    }
     if (open_chars.find(statement_open[0]) == std::string::npos) {
       open_chars += statement_open[0];
     }

--- a/test/unit-renderer.cpp
+++ b/test/unit-renderer.cpp
@@ -388,4 +388,17 @@ TEST_CASE("other-syntax") {
 		CHECK( env.render("Hello {# Test #}", data) == "Hello {# Test #}" );
 		CHECK( env.render("Hello (& Test &)", data) == "Hello " );
 	}
+
+    SECTION("multiple changes") {
+        inja::Environment env;
+        env.set_line_statement("$$");
+        env.set_expression("<%", "%>");
+
+        std::string string_template = R"DELIM(Hello <%name%>
+$$ if name == "Peter"
+    You really are <%name%>
+$$ endif
+)DELIM";
+        CHECK( env.render(string_template, data) == "Hello Peter\n    You really are Peter\n");
+    }
 }


### PR DESCRIPTION
When updating the `opening_chars`, line_statment was forgotten. So, a
change to any of the openers would cause line statements to start being
unrecognized.

I added a unit test to cover this case.