### PR TITLE
Remove unneed linking in update_loop_data

### DIFF
--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -106,20 +106,8 @@ class Renderer {
     }
   }
 
-  void update_loop_data(bool link = true)  {
+  void update_loop_data()  {
     LoopLevel& level = m_loop_stack.back();
-
-    if (link && (m_loop_stack.size() > 1)) {
-      for (int i = m_loop_stack.size() - 2; i >= 0; i--) {
-        auto& level_it = m_loop_stack.at(i);
-
-        if (level_it.loop_type == LoopLevel::Type::Array) {
-          level.data[static_cast<std::string>(level_it.value_name)] = level_it.values.at(level_it.index);
-        } else {
-          level.data[static_cast<std::string>(level_it.value_name)] = *level_it.map_it->second;
-        }
-      }
-    }
 
     if (level.loop_type == LoopLevel::Type::Array) {
       level.data[static_cast<std::string>(level.value_name)] = level.values.at(level.index); // *level.it;
@@ -551,7 +539,7 @@ class Renderer {
             break;
           }
 
-          update_loop_data(false);
+          update_loop_data();
 
           // jump back to start of loop
           i = bc.args - 1;  // -1 due to ++i in loop

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2710,20 +2710,8 @@ class Renderer {
     }
   }
 
-  void update_loop_data(bool link = true)  {
+  void update_loop_data()  {
     LoopLevel& level = m_loop_stack.back();
-
-    if (link && (m_loop_stack.size() > 1)) {
-      for (int i = m_loop_stack.size() - 2; i >= 0; i--) {
-        auto& level_it = m_loop_stack.at(i);
-
-        if (level_it.loop_type == LoopLevel::Type::Array) {
-          level.data[static_cast<std::string>(level_it.value_name)] = level_it.values.at(level_it.index);
-        } else {
-          level.data[static_cast<std::string>(level_it.value_name)] = *level_it.map_it->second;
-        }
-      }
-    }
 
     if (level.loop_type == LoopLevel::Type::Array) {
       level.data[static_cast<std::string>(level.value_name)] = level.values.at(level.index); // *level.it;
@@ -3155,7 +3143,7 @@ class Renderer {
             break;
           }
 
-          update_loop_data(false);
+          update_loop_data();
 
           // jump back to start of loop
           i = bc.args - 1;  // -1 due to ++i in loop


### PR DESCRIPTION
Commit a5862a0 made the linking step in update_loop_data unecessary
because the loop's copy of the data was made to come from the parent
loop's data rather than the original client's data.

While at it, also add one more nested loop test case.