### PR TITLE
Add meson target to update single include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 
 target_link_libraries(inja INTERFACE ${INJA_SELECTED_JSON_LIBRARY})
 
-execute_process(COMMAND python3 amalgamate/amalgamate.py -c amalgamate/config.json -s include WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+execute_process(COMMAND scripts/update_single_include.sh WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 
 if (COVERALLS)

--- a/amalgamate/config.json
+++ b/amalgamate/config.json
@@ -2,7 +2,7 @@
 	"project": "inja",
 	"target": "single_include/inja/inja.hpp",
 	"sources": [
-		"../include/inja/inja.hpp"
+		"inja/inja.hpp"
 	],
 	"include_paths": [
 	]

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,20 @@ inja_dep = declare_dependency(
 )
 
 
+
+amalg_script = files('scripts/update_single_include.sh')
+
+amalg_files = files(
+    'include/inja/inja.hpp',
+	'include/inja/renderer.hpp',
+	'include/inja/environment.hpp',
+	)
+
+amalg_tgt = run_target( 'amalg', 
+	command: amalg_script
+	)
+
+
 inja_test = executable(
   'inja_test',
   'test/unit.cpp',
@@ -17,6 +31,16 @@ inja_test = executable(
   'test/unit-renderer.cpp',
   dependencies: inja_dep
 )
+
+inja_single_test = executable(
+  'inja_single_test',
+  'test/unit.cpp',
+  'test/unit-files.cpp',
+  'test/unit-renderer.cpp',
+  'single_include/inja/inja.hpp',
+  dependencies: [inja_dep]
+)
+
 
 inja_benchmark = executable(
   'inja_benchmark',
@@ -26,3 +50,4 @@ inja_benchmark = executable(
 
 
 test('Inja unit test', inja_test)
+test('Inja single include test', inja_single_test)

--- a/scripts/update_single_include.sh
+++ b/scripts/update_single_include.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if [ "${MESON_SOURCE_ROOT}" != "" ]
+then
+    cd ${MESON_SOURCE_ROOT}
+fi
+
+python3 amalgamate/amalgamate.py -c amalgamate/config.json -s include -v yes


### PR DESCRIPTION
- You can now update the single include file in a meson build by using
the target 'amalg'.
- The meson build also now builds the single include test suite.
- cmake build updated to use the new script to update the single
include.