### PR TITLE
[report-ci] Shameless self promotion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,8 @@ after_success: |
     doxygen ./Doxyfile
   fi
 
+  python <(curl https://report.ci/upload.py) --name "Travis-Ci [ $TRAVIS_OS_NAME, $TRAVIS_OSX_IMAGE $COMPILER ] build"
+
 deploy:
   provider: pages
   skip_cleanup: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(BUILD_TESTING)
   )
   target_link_libraries(inja_test PRIVATE inja)
 
-  add_test(inja_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/inja_test)
+  add_test(inja_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/inja_test  --reporter=xml -s --out=${CMAKE_CURRENT_BINARY_DIR}/inja_test.xml)
 
 
   add_library(single_inja INTERFACE)
@@ -98,7 +98,7 @@ if(BUILD_TESTING)
   )
   target_link_libraries(single_inja_test PRIVATE single_inja)
 
-  add_test(single_inja_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/single_inja_test)
+  add_test(single_inja_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/single_inja_test --reporter=xml -s --out=${CMAKE_CURRENT_BINARY_DIR}/single_inja_test.xml)
 endif()
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,3 +23,6 @@ build_script:
 
 test_script:
   - ctest -C Release -V -j
+
+on_finish:
+  - curl -s https://report.ci/upload.py | python - --name "Appveyor [ %GENERATOR%, %platform% ]"


### PR DESCRIPTION
Heya, I built a small tool to display unit test results, called [report.ci](https://report.ci). 

Since I want users, I now go around and set it up for projects using frameworks I support, and here's how it looks [in action](https://github.com/report-ci/inja/runs/97701598). Note that I added `-s` to the test execution (`add_test` in CMake) so that annotations are shown for passing tests; if you disable that, this should work. 

Feedback is highly appreciated!