### PR TITLE
update the version of nlohmann/json in requirements.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(COVERALLS "Generate coveralls data" OFF)
 
 set(INJA_INSTALL_INCLUDE_DIR "include")
 
-set(CMAKE_CXX_STANDARD 17)
+# set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_BUILD_TYPE Debug)
 # set(CMAKE_BUILD_TYPE Release)
@@ -36,7 +36,7 @@ target_include_directories(inja INTERFACE
   $<INSTALL_INTERFACE:${INJA_INSTALL_INCLUDE_DIR}>
 )
 
-target_compile_features(inja INTERFACE cxx_std_11)
+# target_compile_features(inja INTERFACE cxx_std_11)
 
 set(INJA_PACKAGE_USE_EMBEDDED_JSON OFF)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nlohmann/json@v3.5.0
+nlohmann/json@v3.6.1


### PR DESCRIPTION
`nlohmann/json` has down graded the required version of CMake, this PR updates the version to ensure that `inja` can be build with a lower version of CMake.