### PR TITLE
Add more build configurations to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,43 @@
 version: '{build}'
 
+image:
+  - Visual Studio 2019
+
+platform:
+  - Win32
+  - x64
+
+configuration:
+#  - Debug
+  - Release
+
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      FLAGS: "/permissive- /std:c++17 /utf-8 /Zc:__cplusplus"
-      GENERATOR: Visual Studio 15 2017
+    # Visual Studio 2015
+#    - TOOLCHAIN: v140
+#      STD: 14
+    # Visual Studio 2017
+    - TOOLCHAIN: v141
+      STD: 14
+    - TOOLCHAIN: v141
+      STD: 17
+    # Visual Studio 2019
+    - TOOLCHAIN: v142
+      STD: 14
+    - TOOLCHAIN: v142
+      STD: 17
 
 init:
   - cmake --version
   - msbuild /version
 
-install: []
-
 before_build:
   - mkdir -p build
   - cd build
-  - cmake .. -G "%GENERATOR%" -DCMAKE_CXX_FLAGS="%FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
+  - cmake .. -A %PLATFORM% -T %TOOLCHAIN% -DCMAKE_CXX_STANDARD=%STD% -DCMAKE_CXX_FLAGS="/permissive- /utf-8 /Zc:__cplusplus"
 
 build_script:
-  - cmake --build . --config Release
+  - cmake --build . --config %CONFIGURATION% -- -verbosity:n
 
 test_script:
-  - ctest -C Release -V -j
+  - ctest -C %CONFIGURATION% -V -j


### PR DESCRIPTION
Hi,

I'd like to add more build configurations on Appveyor:
* Debug/Release
* x86/x64
* VS 2015/2017/2019
* C++ standard: 14/17

Currently VS 2015 and all Debug builds fail (you can see full status on this appveyor [job]( https://ci.appveyor.com/project/kzeslaf/inja/builds/28721345)) so I've commented these configurations out. I will try to fix them in additional pull requests.

Additionally I raised build output verbosity to see all build flags in appveyor build output, option: `-verbosity:n`.