### PR TITLE
Fix Visual Studio Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,11 @@ set(INJA_INSTALL_INCLUDE_DIR "include")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 if(CMAKE_COMPILER_IS_GNUCC)
-  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
+  add_compile_options(-Wall)
 endif()
 
 if(MSVC)
-  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /W4")
+  add_compile_options(/W4 /permissive- /utf-8 /Zc:__cplusplus)
 endif()
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ platform:
   - x64
 
 configuration:
-#  - Debug
+  - Debug
   - Release
 
 environment:
@@ -34,7 +34,7 @@ init:
 before_build:
   - mkdir -p build
   - cd build
-  - cmake .. -A %PLATFORM% -T %TOOLCHAIN% -DCMAKE_CXX_STANDARD=%STD% -DCMAKE_CXX_FLAGS="/permissive- /utf-8 /Zc:__cplusplus"
+  - cmake .. -A %PLATFORM% -T %TOOLCHAIN% -DCMAKE_CXX_STANDARD=%STD%
 
 build_script:
   - cmake --build . --config %CONFIGURATION% -- -verbosity:n


### PR DESCRIPTION
Hi,

removing build flags `-DCMAKE_CXX_FLAGS="..."` from appveyor.yml file and moving them to CMakeLists.txt fixes Debug builds. Setting `CMAKE_CXX_FLAGS` on command line overrides default compile options set by cmake.

I've checked two builds (VS2017, C++17, x64) Debug and Release and now builds have following additional flags set:
```
/D WIN32 /D _WINDOWS /EHsc /GR
```