### PR TITLE
Add CMake option to control Inja's unit tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(INJA_USE_EMBEDDED_JSON "Use the shipped json header if not available on t
 option(INJA_INSTALL "Generate install targets for inja" ON)
 option(INJA_EXPORT "Export the current build tree to the package registry" ON)
 option(BUILD_TESTING "Build unit tests" ON)
+option(INJA_BUILD_TESTS "Build unit tests when BUILD_TESTING is enabled." ON)
 option(BUILD_BENCHMARK "Build benchmark" ON)
 option(COVERALLS "Generate coveralls data" OFF)
 
@@ -71,7 +72,7 @@ target_link_libraries(inja INTERFACE ${INJA_SELECTED_JSON_LIBRARY})
 execute_process(COMMAND scripts/update_single_include.sh WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND INJA_BUILD_TESTS)
   enable_testing()
 
   add_executable(inja_test


### PR DESCRIPTION
First, thanks for creating this awesome library!

Currently Inja's CMake config will build unit tests as long as the `BUILD_TESTING` option is enabled. As a result, when including Inja in another CMake project, it is not possible to build the latter's unit tests without also enabling Inja's own unit tests.

It's common for libraries to include a separate option for controlling its own unit test targets, in addition to observing the global `BUILD_TESTING` option. For instance, nlohmann/json has a `JSON_BuildTests` option: https://github.com/nlohmann/json/blob/973c52dd4a9e92ede5ca4afe8b3d01ef677dc57f/CMakeLists.txt#L18

Also see https://cliutils.gitlab.io/modern-cmake/chapters/testing.html .

This commit adds a `INJA_BUILD_TESTS` flag to address this.