### PR TITLE
Making it compatible with gcc 4.8

### DIFF
--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -157,7 +157,8 @@ public:
   }
 
   json load_json(const std::string &filename) {
-    std::ifstream file = open_file_or_throw(input_path + filename);
+    std::ifstream file;
+    open_file_or_throw(input_path + filename, file);
     json j;
     file >> j;
     return j;

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -540,7 +540,8 @@ public:
   }
 
   std::string load_file(nonstd::string_view filename) {
-    std::ifstream file = open_file_or_throw(static_cast<std::string>(filename));
+    std::ifstream file;
+    open_file_or_throw(static_cast<std::string>(filename), file);
     std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     return text;
   }

--- a/include/inja/utils.hpp
+++ b/include/inja/utils.hpp
@@ -13,15 +13,13 @@
 
 namespace inja {
 
-inline std::ifstream open_file_or_throw(const std::string &path) {
-  std::ifstream file;
+inline void open_file_or_throw(const std::string &path, std::ifstream &file) {
   file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   try {
     file.open(path);
   } catch (const std::ios_base::failure & /*e*/) {
     throw FileError("failed accessing file at '" + path + "'");
   }
-  return file;
 }
 
 namespace string_view {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1829,15 +1829,13 @@ struct Token {
 
 namespace inja {
 
-inline std::ifstream open_file_or_throw(const std::string &path) {
-  std::ifstream file;
+inline void open_file_or_throw(const std::string &path, std::ifstream &file) {
   file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   try {
     file.open(path);
   } catch (const std::ios_base::failure & /*e*/) {
     throw FileError("failed accessing file at '" + path + "'");
   }
-  return file;
 }
 
 namespace string_view {
@@ -3222,7 +3220,8 @@ public:
   }
 
   std::string load_file(nonstd::string_view filename) {
-    std::ifstream file = open_file_or_throw(static_cast<std::string>(filename));
+    std::ifstream file;
+    open_file_or_throw(static_cast<std::string>(filename), file);
     std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     return text;
   }
@@ -3971,7 +3970,8 @@ public:
   }
 
   json load_json(const std::string &filename) {
-    std::ifstream file = open_file_or_throw(input_path + filename);
+    std::ifstream file;
+    open_file_or_throw(input_path + filename, file);
     json j;
     file >> j;
     return j;


### PR DESCRIPTION
There is an inline function that assumes the compiler has copy elision
optimization which is actually not required until C++17. GCC 4.8 does it
but it requires the copy constructor to be defined which is not the case
for std::ifstream. Fixed by passing reference by parameter.