### PR TITLE
Using another method for exists call

### DIFF
--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -334,7 +334,7 @@ class Renderer : public NodeVisitor  {
     } break;
     case Op::Exists: {
       auto &&name = get_arguments<1>(node)[0]->get_ref<const std::string &>();
-      result_ptr = std::make_shared<json>(json_input->find(name) != json_input->end());
+      result_ptr = std::make_shared<json>(json_input->contains(json::json_pointer(JsonNode(name, 0).ptr)));
       json_tmp_stack.push_back(result_ptr);
       json_eval_stack.push(result_ptr.get());
     } break;

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -3576,7 +3576,7 @@ class Renderer : public NodeVisitor  {
     } break;
     case Op::Exists: {
       auto &&name = get_arguments<1>(node)[0]->get_ref<const std::string &>();
-      result_ptr = std::make_shared<json>(json_input->find(name) != json_input->end());
+      result_ptr = std::make_shared<json>(json_input->contains(json::json_pointer(JsonNode(name, 0).ptr)));
       json_tmp_stack.push_back(result_ptr);
       json_eval_stack.push(result_ptr.get());
     } break;


### PR DESCRIPTION
This PR re-implements the exists() call by using `json->contains(json::json_pointer(JsonNode(name, 0).ptr));` instead of `json->find()`, which allows you to call `exists("array.1.name")` safely with no throw regardless of the existence of the array, the item in this array, or the `name` key in this item, so that you don't need to `exists("array")`, `existsIn("1", array)` and `existsIn("name", array.1)`.