### PR TITLE
Switched order in token::kind::id of function and operator behavior

### DIFF
--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -139,14 +139,14 @@ class Parser {
             add_json_literal(tmpl.content.c_str());
           }
 
+	// Operator
+        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
+          goto parse_operator;
+
         // Functions
         } else if (peek_tok.kind == Token::Kind::LeftParen) {
           operator_stack.emplace(std::make_shared<FunctionNode>(static_cast<std::string>(tok.text), tok.text.data() - tmpl.content.c_str()));
-          function_stack.emplace(operator_stack.top().get(), current_paren_level);
-
-        // Operator
-        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
-          goto parse_operator;
+          function_stack.emplace(operator_stack.top().get(), current_paren_level);       
 
         // Variables
         } else {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2835,14 +2835,14 @@ class Parser {
             add_json_literal(tmpl.content.c_str());
           }
 
+	// Operator
+        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
+          goto parse_operator;
+
         // Functions
         } else if (peek_tok.kind == Token::Kind::LeftParen) {
           operator_stack.emplace(std::make_shared<FunctionNode>(static_cast<std::string>(tok.text), tok.text.data() - tmpl.content.c_str()));
-          function_stack.emplace(operator_stack.top().get(), current_paren_level);
-
-        // Operator
-        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
-          goto parse_operator;
+          function_stack.emplace(operator_stack.top().get(), current_paren_level);       
 
         // Variables
         } else {

--- a/test/test-functions.cpp
+++ b/test/test-functions.cpp
@@ -268,4 +268,7 @@ TEST_CASE("combinations") {
   CHECK(env.render("{{ last(list_of_objects).d * 2}}", data) == "10");
   CHECK(env.render("{{ last(range(5)) * 2 }}", data) == "8");
   CHECK(env.render("{{ last(range(5 * 2)) }}", data) == "9");
+  CHECK(env.render("{{ not true }}", data) == "false");
+  CHECK(env.render("{{ not (true) }}", data) == "false");
+  CHECK(env.render("{{ true or (true or true) }}", data) == "true");
 }


### PR DESCRIPTION
#154 

Switching the order of function and operator behavior in the parser seems to fix the issue.
The occuring problem was that logic operators (or, and, not) were looked up as functions.