### PR TITLE
Fixed lookup of variables

### DIFF
--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -161,11 +161,11 @@ class Renderer : public NodeVisitor  {
 
     try {
       // First try to evaluate as a loop variable
-      if (json_loop_data.contains(ptr)) {
-        json_eval_stack.push(&json_loop_data.at(ptr));
-      } else {
-        json_eval_stack.push(&json_input->at(ptr));
-      }
+      try {
+	      json_eval_stack.push(&json_loop_data.at(ptr));
+	    }  catch (json::out_of_range & ) {
+	      json_eval_stack.push(&json_input->at(ptr));
+	    }
 
     } catch (std::exception &) {
       // Try to evaluate as a no-argument callback


### PR DESCRIPTION
It seems that a check with 'contains' fails on json data with json_pointer .
Therefore _at(...)_ is used with a try&catch since it seems to be only option to even check deeper in the object.

Occured with #156 and seems to fix it.
This also was caused by loop.index and so one.

Don't really like it but couldn't find another check for existence while looking not only one level.
