### PR TITLE
Execute statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,12 @@ Variables can also be defined within the template using the set statment.
 ```.cpp
 render("{% set new_hour=23 %}{{ new_hour }}pm", data); // "23pm"
 ```
+#### Execute Statement
 
+Functions can be executed without being rendered.
+```.cpp
+render("{% execute max(4) %}{{ neightbour }}", data); // "Peter", max(4) is executed
+```
 
 ### Functions
 

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -29,6 +29,7 @@ class ForObjectStatementNode;
 class IfStatementNode;
 class IncludeStatementNode;
 class SetStatementNode;
+class ExecuteStatementNode;
 
 
 class NodeVisitor {
@@ -47,6 +48,7 @@ public:
   virtual void visit(const IfStatementNode& node) = 0;
   virtual void visit(const IncludeStatementNode& node) = 0;
   virtual void visit(const SetStatementNode& node) = 0;
+  virtual void visit(const ExecuteStatementNode& node) = 0;
 };
 
 /*!
@@ -319,6 +321,17 @@ public:
   ExpressionListNode expression;
 
   explicit SetStatementNode(const std::string& key, size_t pos) : StatementNode(pos), key(key) { }
+
+  void accept(NodeVisitor& v) const {
+    v.visit(*this);
+  };
+};
+
+class ExecuteStatementNode : public StatementNode {
+public:
+  ExpressionListNode expression;
+
+  explicit ExecuteStatementNode(size_t pos) : StatementNode(pos) { }
 
   void accept(NodeVisitor& v) const {
     v.visit(*this);

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -477,7 +477,20 @@ class Parser {
       if (!parse_expression(tmpl, closing)) {
         return false;
       }
+      
 
+    } else if (tok.text == static_cast<decltype(tok.text)>("execute")) {
+      get_next_token();
+      
+      auto execute_statement_node = std::make_shared<ExecuteStatementNode>(tok.text.data() - tmpl.content.c_str());
+      current_block->nodes.emplace_back(execute_statement_node);
+      current_expression_list = &execute_statement_node->expression;
+      
+      if (!parse_expression(tmpl, closing)) {
+        return false;
+      }
+      
+    	
     } else {
       return false;
     }

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -139,14 +139,14 @@ class Parser {
             add_json_literal(tmpl.content.c_str());
           }
 
+	// Operator
+        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
+          goto parse_operator;
+
         // Functions
         } else if (peek_tok.kind == Token::Kind::LeftParen) {
           operator_stack.emplace(std::make_shared<FunctionNode>(static_cast<std::string>(tok.text), tok.text.data() - tmpl.content.c_str()));
-          function_stack.emplace(operator_stack.top().get(), current_paren_level);
-
-        // Operator
-        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
-          goto parse_operator;
+          function_stack.emplace(operator_stack.top().get(), current_paren_level);       
 
         // Variables
         } else {

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -579,6 +579,10 @@ class Renderer : public NodeVisitor  {
   void visit(const SetStatementNode& node) {
     json_additional_data[node.key] = *eval_expression_list(node.expression);
   }
+  
+  void visit(const ExecuteStatementNode& node) {
+		eval_expression_list(node.expression);
+  }
 
 public:
   Renderer(const RenderConfig& config, const TemplateStorage &template_storage, const FunctionStorage &function_storage)

--- a/include/inja/statistics.hpp
+++ b/include/inja/statistics.hpp
@@ -56,6 +56,8 @@ class StatisticsVisitor : public NodeVisitor {
   void visit(const IncludeStatementNode&) { }
 
   void visit(const SetStatementNode&) { }
+  
+  void visit(const ExecuteStatementNode&) { }
 
 public:
   unsigned int variable_counter;

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2835,14 +2835,14 @@ class Parser {
             add_json_literal(tmpl.content.c_str());
           }
 
+	// Operator
+        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
+          goto parse_operator;
+
         // Functions
         } else if (peek_tok.kind == Token::Kind::LeftParen) {
           operator_stack.emplace(std::make_shared<FunctionNode>(static_cast<std::string>(tok.text), tok.text.data() - tmpl.content.c_str()));
-          function_stack.emplace(operator_stack.top().get(), current_paren_level);
-
-        // Operator
-        } else if (tok.text == "and" || tok.text == "or" || tok.text == "in" || tok.text == "not") {
-          goto parse_operator;
+          function_stack.emplace(operator_stack.top().get(), current_paren_level);       
 
         // Variables
         } else {

--- a/test/test-functions.cpp
+++ b/test/test-functions.cpp
@@ -268,4 +268,7 @@ TEST_CASE("combinations") {
   CHECK(env.render("{{ last(list_of_objects).d * 2}}", data) == "10");
   CHECK(env.render("{{ last(range(5)) * 2 }}", data) == "8");
   CHECK(env.render("{{ last(range(5 * 2)) }}", data) == "9");
+  CHECK(env.render("{{ not true }}", data) == "false");
+  CHECK(env.render("{{ not (true) }}", data) == "false");
+  CHECK(env.render("{{ true or (true or true) }}", data) == "true");
 }


### PR DESCRIPTION
Similar to the set statement i was in need of a execute statement.

The execute statement executes a given expression but doesn't render it.
This helps to call functions that just want to be executed.
For example, adding a debug function that dumps the object but doesn't change the result.

I would love to have this or something similar added.

```
{% execute a_dump_function(data) -%} Something was dumped.
```
Would just result in "Something was dumped."

This use case is just an example. Not a good one to be honest.
The issue is that currently no option is available to just call a function without rendering something.
Using an expression and returning "" doesn't allow for whitespace control.