### PR TITLE
Suppress "missing initializer" warnings

### DIFF
--- a/include/inja/function_storage.hpp
+++ b/include/inja/function_storage.hpp
@@ -71,7 +71,7 @@ public:
   };
 
   struct FunctionData {
-    FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
+    explicit FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
     const Operation operation;
     const CallbackFunction callback;
   };
@@ -130,7 +130,7 @@ public:
       }
     }
 
-    return { Operation::None };
+    return FunctionData { Operation::None };
   }
 };
 

--- a/include/inja/function_storage.hpp
+++ b/include/inja/function_storage.hpp
@@ -72,7 +72,7 @@ public:
 
   struct FunctionData {
     const Operation operation;
-    const CallbackFunction callback;
+    const CallbackFunction callback {};
   };
 
 private:

--- a/include/inja/function_storage.hpp
+++ b/include/inja/function_storage.hpp
@@ -71,7 +71,7 @@ public:
   };
 
   struct FunctionData {
-    const Operation operation;
+    const Operation operation {};
     const CallbackFunction callback {};
   };
 

--- a/include/inja/function_storage.hpp
+++ b/include/inja/function_storage.hpp
@@ -71,8 +71,9 @@ public:
   };
 
   struct FunctionData {
-    const Operation operation {};
-    const CallbackFunction callback {};
+    FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
+    const Operation operation;
+    const CallbackFunction callback;
   };
 
 private:

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1589,7 +1589,7 @@ public:
   };
 
   struct FunctionData {
-    FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
+    explicit FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
     const Operation operation;
     const CallbackFunction callback;
   };
@@ -1648,7 +1648,7 @@ public:
       }
     }
 
-    return { Operation::None };
+    return FunctionData { Operation::None };
   }
 };
 

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1590,7 +1590,7 @@ public:
 
   struct FunctionData {
     const Operation operation;
-    const CallbackFunction callback;
+    const CallbackFunction callback {};
   };
 
 private:

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1589,8 +1589,9 @@ public:
   };
 
   struct FunctionData {
-    const Operation operation {};
-    const CallbackFunction callback {};
+    FunctionData(const Operation &op, const CallbackFunction &cb = CallbackFunction{}) : operation(op), callback(cb) {}
+    const Operation operation;
+    const CallbackFunction callback;
   };
 
 private:

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1589,7 +1589,7 @@ public:
   };
 
   struct FunctionData {
-    const Operation operation;
+    const Operation operation {};
     const CallbackFunction callback {};
   };
 


### PR DESCRIPTION
Suppress `missing initializer for member 'inja::FunctionStorage::FunctionData::callback'` warnings by adding a constructor with empty default value to `callback`.