### PR TITLE
Do not install nlohmann json if it is not embedded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,11 +161,13 @@ if(INJA_INSTALL)
     DESTINATION ${INJA_INSTALL_INCLUDE_DIR}
     FILES_MATCHING PATTERN "*.hpp"
   )
-  install(
-    DIRECTORY third_party/include/nlohmann
-    DESTINATION ${INJA_INSTALL_INCLUDE_DIR}
-    FILES_MATCHING PATTERN "*.hpp"
-  )
+  if(INJA_USE_EMBEDDED_JSON)
+    install(
+      DIRECTORY third_party/include/nlohmann
+      DESTINATION ${INJA_INSTALL_INCLUDE_DIR}
+      FILES_MATCHING PATTERN "*.hpp"
+    )
+  endif()
   install(
     FILES
       "${CMAKE_CURRENT_BINARY_DIR}/${INJA_CONFIG_PATH}/injaConfig.cmake"


### PR DESCRIPTION
This fixes https://github.com/pantor/inja/issues/175

The problem is that the `nlohmann/json.hpp` is included in the install directory even if the `INJA_USE_EMBEDDED_JSON` is set to `OFF`.

If `nlohmann/json.hpp` comes from another place (for example, a different version than the one in the `thid_party` folder), then you probably do not want to copy the embedded one it into the install directory.

This PR fixes that.