### PR TITLE
Disabled immediate config on Linux CI libc6-dbg install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           
           sudo apt-get update
           # libc6-dbg:i386 is required for running valgrind on x86.
-          sudo apt-get install -y ninja-build valgrind libc6-dbg:i386
+          sudo apt-get install -y ninja-build valgrind libc6-dbg:i386 -o APT::Immediate-Configure=0
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
             echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV


### PR DESCRIPTION
This should fix the Ubuntu 20.04 CI failures.

Taken from an issue on the Docker for linux repo and a few other places:

https://github.com/docker/for-linux/issues/1131

Ubuntu bug report also seems to indicate this is safe:

https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268