### PR TITLE
Fix inclusion in translation units with exceptions disabled.

### DIFF
--- a/include/inja/inja.hpp
+++ b/include/inja/inja.hpp
@@ -10,6 +10,9 @@
 #else
     #include <cstdlib>
     #define INJA_THROW(exception) std::abort()
+    #ifndef INJA_NOEXCEPTION
+      #define INJA_NOEXCEPTION
+    #endif
 #endif
 
 #include "environment.hpp"

--- a/include/inja/utils.hpp
+++ b/include/inja/utils.hpp
@@ -15,11 +15,15 @@ namespace inja {
 
 inline void open_file_or_throw(const std::string &path, std::ifstream &file) {
   file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+#ifndef INJA_NOEXCEPTION
   try {
     file.open(path);
   } catch (const std::ios_base::failure & /*e*/) {
     INJA_THROW(FileError("failed accessing file at '" + path + "'"));
   }
+#else
+  file.open(path);
+#endif
 }
 
 namespace string_view {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -10,6 +10,9 @@
 #else
     #include <cstdlib>
     #define INJA_THROW(exception) std::abort()
+    #ifndef INJA_NOEXCEPTION
+      #define INJA_NOEXCEPTION
+    #endif
 #endif
 
 // #include "environment.hpp"
@@ -1842,11 +1845,15 @@ namespace inja {
 
 inline void open_file_or_throw(const std::string &path, std::ifstream &file) {
   file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+#ifndef INJA_NOEXCEPTION
   try {
     file.open(path);
   } catch (const std::ios_base::failure & /*e*/) {
     INJA_THROW(FileError("failed accessing file at '" + path + "'"));
   }
+#else
+  file.open(path);
+#endif
 }
 
 namespace string_view {


### PR DESCRIPTION
If exceptions are disabled via `-fno-exceptions`, the use of try-catch is
disallowed by the compiler.

This patch does two things:
* Gates the use of try-catch in one translation unit on the definition of
  `INJA_NOEXCEPTION`.
* Make it such that translation units compiled with `-fno-exceptions` but no
  `INJA_NOEXCEPTION` implicitly sets `INJA_NOEXCEPTION`.

In the specific case of `ifstream::open`, setting the exceptions bits without
exceptions enabled should trip an assertion just like INJA_ABORT. The nice
message will not be present however, but that is absent when using INJA_ABORT as
well.

After this patch, inja can be successfully included without issue.