### PR TITLE
Fix build warnings for Clang and MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ dist
 .coveralls.yml
 
 .vscode
+.vs
 
 doc/html
 doc/latex

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -33,6 +33,8 @@ class SetStatementNode;
 
 class NodeVisitor {
 public:
+  virtual ~NodeVisitor() = default;
+
   virtual void visit(const BlockNode& node) = 0;
   virtual void visit(const TextNode& node) = 0;
   virtual void visit(const ExpressionNode& node) = 0;

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -59,7 +59,7 @@ public:
   size_t pos;
 
   AstNode(size_t pos) : pos(pos) { }
-  virtual ~AstNode() { };
+  virtual ~AstNode() { }
 };
 
 
@@ -326,7 +326,7 @@ public:
 
   void accept(NodeVisitor& v) const {
     v.visit(*this);
-  };
+  }
 };
 
 class SetStatementNode : public StatementNode {
@@ -338,7 +338,7 @@ public:
 
   void accept(NodeVisitor& v) const {
     v.visit(*this);
-  };
+  }
 };
 
 } // namespace inja

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -304,7 +304,7 @@ class Renderer : public NodeVisitor  {
     case Op::Power: {
       auto args = get_arguments<2>(node);
       if (args[0]->is_number_integer() && args[1]->get<int>() >= 0) {
-        int result = std::pow(args[0]->get<int>(), args[1]->get<int>());
+        int result = static_cast<int>(std::pow(args[0]->get<int>(), args[1]->get<int>()));
         result_ptr = std::make_shared<json>(std::move(result));
         json_tmp_stack.push_back(result_ptr);
       } else {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2377,7 +2377,7 @@ public:
   size_t pos;
 
   AstNode(size_t pos) : pos(pos) { }
-  virtual ~AstNode() { };
+  virtual ~AstNode() { }
 };
 
 
@@ -2644,7 +2644,7 @@ public:
 
   void accept(NodeVisitor& v) const {
     v.visit(*this);
-  };
+  }
 };
 
 class SetStatementNode : public StatementNode {
@@ -2656,7 +2656,7 @@ public:
 
   void accept(NodeVisitor& v) const {
     v.visit(*this);
-  };
+  }
 };
 
 } // namespace inja

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2351,6 +2351,8 @@ class SetStatementNode;
 
 class NodeVisitor {
 public:
+  virtual ~NodeVisitor() = default;
+
   virtual void visit(const BlockNode& node) = 0;
   virtual void visit(const TextNode& node) = 0;
   virtual void visit(const ExpressionNode& node) = 0;

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -3674,7 +3674,7 @@ class Renderer : public NodeVisitor  {
     case Op::Power: {
       auto args = get_arguments<2>(node);
       if (args[0]->is_number_integer() && args[1]->get<int>() >= 0) {
-        int result = std::pow(args[0]->get<int>(), args[1]->get<int>());
+        int result = static_cast<int>(std::pow(args[0]->get<int>(), args[1]->get<int>()));
         result_ptr = std::make_shared<json>(std::move(result));
         json_tmp_stack.push_back(result_ptr);
       } else {


### PR DESCRIPTION
Fix some build warnings for Clang and MSVC.
- unnecessary semicolons
- missing virtual desctructor
- implicit conversion from double to int

At the moment I have to disable some warnings when inja is included.
It would be nice if this is no longer needed.
```
#ifdef _MSC_VER
#pragma warning(push)
#pragma warning(disable : 4244)
#else
#pragma clang diagnostic push
#pragma clang diagnostic warning "-Wextra-semi"
#pragma clang diagnostic warning "-Wnon-virtual-dtor"
#endif
#include <inja/inja.hpp>
#ifdef _MSC_VER
#pragma warning(pop)
#else
#pragma clang diagnostic pop
#endif
```