### PR TITLE
Add option to disable tests and benchmarks with Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,9 @@
 project('inja', 'cpp', default_options: ['cpp_std=c++17'])
 
 
-#option('build_tests', type: 'boolean', value: true)
-#option('build_benchmark', type: 'boolean', value: true)
-
-
 inja_dep = declare_dependency(
   include_directories: include_directories('include', 'third_party/include')
 )
-
 
 
 amalg_script = files('scripts/update_single_include.sh')
@@ -23,27 +18,29 @@ amalg_tgt = run_target( 'amalg',
 	command: amalg_script
 )
 
+if get_option('build_tests')
+  inja_test = executable(
+    'inja_test',
+    'test/test.cpp',
+    dependencies: inja_dep
+  )
 
-inja_test = executable(
-  'inja_test',
-  'test/test.cpp',
-  dependencies: inja_dep
-)
+  inja_single_test = executable(
+    'inja_single_test',
+    'test/test.cpp',
+    'single_include/inja/inja.hpp',
+    dependencies: [inja_dep]
+  )
 
-inja_single_test = executable(
-  'inja_single_test',
-  'test/test.cpp',
-  'single_include/inja/inja.hpp',
-  dependencies: [inja_dep]
-)
-
-
-inja_benchmark = executable(
-  'inja_benchmark',
-  'test/benchmark.cpp',
-  dependencies: inja_dep
-)
+  test('Inja unit test', inja_test)
+  test('Inja single include test', inja_single_test)
+endif
 
 
-test('Inja unit test', inja_test)
-test('Inja single include test', inja_single_test)
+if get_option('build_benchmark')
+  inja_benchmark = executable(
+    'inja_benchmark',
+    'test/benchmark.cpp',
+    dependencies: inja_dep
+  )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('build_tests', type: 'boolean', value: true)
+option('build_benchmark', type: 'boolean', value: true)


### PR DESCRIPTION
This adds options to disable building the tests or benchmarks when using inja directly as a subproject in Meson.
By default, both tests and benchmarks will be built.

Changing the values can be done when importing the subproject like this:

    inja_proj = subproject('inja', default_options: [
        'build_benchmark=true',
        'build_tests=false'
    ])