### PR TITLE
add support for JSON_NO_IO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,10 +227,24 @@ jobs:
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug
           cmake --build build -j2
           cd build && ctest -j2 --output-on-failure
-        
+
+      - name: Build & Test Debug with JSON_NO_IO
+        run: |
+          cmake -E remove_directory build
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DINJA_TEST_JSON_NO_IO=ON
+          cmake --build build -j2
+          cd build && ctest -j2 --output-on-failure
+
       - name: Build & Test Release
         run: |
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_vars }}
+          cmake --build build -j2
+          cd build && ctest -j2 --output-on-failure
+
+      - name: Build & Test Release with JSON_NO_IO
+        run: |
+          cmake -E remove_directory build
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DINJA_TEST_JSON_NO_IO=ON ${{ matrix.cmake_vars }}
           cmake --build build -j2
           cd build && ctest -j2 --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(BUILD_TESTING "Build unit tests" ON)
 option(INJA_BUILD_TESTS "Build unit tests when BUILD_TESTING is enabled." ON)
 option(BUILD_BENCHMARK "Build benchmark" ON)
 option(COVERALLS "Generate coveralls data" OFF)
+option(INJA_TEST_JSON_NO_IO "Build unit tests with definition JSON_NO_IO=1." OFF)
 
 
 set(INJA_INSTALL_INCLUDE_DIR "include")
@@ -94,6 +95,11 @@ if(BUILD_TESTING AND INJA_BUILD_TESTS)
   target_link_libraries(single_inja_test PRIVATE single_inja)
 
   add_test(single_inja_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/single_inja_test)
+
+  if(INJA_TEST_JSON_NO_IO)
+    target_compile_definitions(inja_test PRIVATE JSON_NO_IO)
+    target_compile_definitions(single_inja_test PRIVATE JSON_NO_IO)
+  endif()
 endif()
 
 

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -166,7 +166,12 @@ public:
       INJA_THROW(FileError("failed accessing file at '" + input_path + filename + "'"));
     }
     json j;
+
+#ifdef JSON_NO_IO
+    j = json::parse(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+#else
     file >> j;
+#endif
     return j;
   }
 

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -458,7 +458,11 @@ class Renderer : public NodeVisitor {
         if (value.is_string()) {
           os << value.get<std::string>(); // otherwise the value is surrounded with ""
         } else {
+#ifdef JSON_NO_IO
+          os << value.dump();
+#else
           os << value;
+#endif
         }
         sep = separator;
       }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2538,7 +2538,11 @@ class Renderer : public NodeVisitor {
         if (value.is_string()) {
           os << value.get<std::string>(); // otherwise the value is surrounded with ""
         } else {
+#ifdef JSON_NO_IO
+          os << value.dump();
+#else
           os << value;
+#endif
         }
         sep = separator;
       }
@@ -2868,7 +2872,12 @@ public:
       INJA_THROW(FileError("failed accessing file at '" + input_path + filename + "'"));
     }
     json j;
+
+#ifdef JSON_NO_IO
+    j = json::parse(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+#else
     file >> j;
+#endif
     return j;
   }
 


### PR DESCRIPTION
Add Cmake option and CI test for the macro `JSON_NO_IO`.

The `JSON_NO_IO` is added in nlohmann_json in v3.10.0, but the embedded `nlohmann/json.hpp` is v3.9.1, this PR would be effective after updating nlohmann_json.