### PR TITLE
Update meson build

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,16 @@
+install_headers(
+  'inja/config.hpp',
+  'inja/environment.hpp',
+  'inja/exceptions.hpp',
+  'inja/function_storage.hpp',
+  'inja/inja.hpp',
+  'inja/lexer.hpp',
+  'inja/node.hpp',
+  'inja/parser.hpp',
+  'inja/renderer.hpp',
+  'inja/statistics.hpp',
+  'inja/template.hpp',
+  'inja/token.hpp',
+  'inja/utils.hpp',
+  subdir: 'inja'
+)

--- a/meson.build
+++ b/meson.build
@@ -1,49 +1,31 @@
-project('inja', 'cpp', default_options: ['cpp_std=c++17'])
-
-
-#option('build_tests', type: 'boolean', value: true)
-#option('build_benchmark', type: 'boolean', value: true)
-
-
-inja_dep = declare_dependency(
-  include_directories: include_directories('include', 'third_party/include')
+project(
+  'inja',
+  'cpp',
+  version: '3.3.0',
+  default_options: [
+    'cpp_std=c++17',
+    'warning_level=3'
+  ],
+  meson_version: '>=0.56'
 )
 
-
-
-amalg_script = files('scripts/update_single_include.sh')
-
-amalg_files = files(
-  'include/inja/inja.hpp',
-	'include/inja/renderer.hpp',
-	'include/inja/environment.hpp',
+run_command(
+  find_program('scripts/update_single_include.sh'),
+  check: true
 )
 
-amalg_tgt = run_target( 'amalg',
-	command: amalg_script
-)
+if get_option('single-header')
+  subdir('single_include')
+  inja_dep = declare_dependency(
+    include_directories: include_directories('single_include', 'third_party/include')
+  )
+else
+  subdir('include')
+  inja_dep = declare_dependency(
+    include_directories: include_directories('include', 'third_party/include')
+  )
+endif
 
-
-inja_test = executable(
-  'inja_test',
-  'test/test.cpp',
-  dependencies: inja_dep
-)
-
-inja_single_test = executable(
-  'inja_single_test',
-  'test/test.cpp',
-  'single_include/inja/inja.hpp',
-  dependencies: [inja_dep]
-)
-
-
-inja_benchmark = executable(
-  'inja_benchmark',
-  'test/benchmark.cpp',
-  dependencies: inja_dep
-)
-
-
-test('Inja unit test', inja_test)
-test('Inja single include test', inja_single_test)
+if get_option('tests')
+  subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('single-header', type: 'boolean', value: false,
+    description: 'Use single header include directory')
+option('tests', type: 'boolean', value: true,
+    description: 'Build tests')

--- a/single_include/meson.build
+++ b/single_include/meson.build
@@ -1,0 +1,1 @@
+install_headers('inja/inja.hpp', subdir: 'inja')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,14 @@
+inja_test = executable(
+  'inja_test',
+  'test.cpp',
+  dependencies: inja_dep
+)
+
+inja_benchmark = executable(
+  'inja_benchmark',
+  'benchmark.cpp',
+  dependencies: inja_dep
+)
+
+test('inja_test', inja_test, workdir: meson.project_build_root())
+benchmark('inja_benchmark', inja_benchmark, workdir: meson.project_build_root())


### PR DESCRIPTION
The way the single header is generated is not good. It needs to be a custom target, but I am just doing what the CMake build is doing. I would advocate for removing the CMake build. This meson build is much better.