### PR TITLE
Search directory for included templates

### DIFF
--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -33,7 +33,7 @@ protected:
   std::string output_path;
 
 public:
-  Environment(): Environment("") {}
+  Environment(): Environment("./") {}
 
   explicit Environment(const std::string& global_path): input_path(global_path), output_path(global_path) {}
 
@@ -95,7 +95,7 @@ public:
 
   Template parse(std::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
-    return parser.parse(input);
+    return parser.parse(input, input_path);
   }
 
   Template parse_template(const std::string& filename) {


### PR DESCRIPTION
Fixes #242.

Currently the input_path directory is searched for included templates only when the main template is passed as a file path. This change expands support to when the main template is passed as a string.