### PR TITLE
Refer the root object by single dot

### DIFF
--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -112,12 +112,12 @@ public:
 
   static std::string convert_dot_to_ptr(std::string_view ptr_name) {
     std::string result;
-    do {
+    while (!ptr_name.empty()) {
       std::string_view part;
       std::tie(part, ptr_name) = string_view::split(ptr_name, '.');
       result.push_back('/');
       result.append(part.begin(), part.end());
-    } while (!ptr_name.empty());
+    }
     return result;
   }
 

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -214,6 +214,12 @@ class Parser {
 
         // Operators
       } break;
+      case Token::Kind::Dot:
+        if (arguments.empty()) {
+          arguments.emplace_back(std::make_shared<DataNode>("", tok.text.data() - tmpl.content.c_str()));
+          break;
+        }
+        [[fallthrough]];
       case Token::Kind::Equal:
       case Token::Kind::NotEqual:
       case Token::Kind::GreaterThan:
@@ -225,8 +231,7 @@ class Parser {
       case Token::Kind::Times:
       case Token::Kind::Slash:
       case Token::Kind::Power:
-      case Token::Kind::Percent:
-      case Token::Kind::Dot: {
+      case Token::Kind::Percent: {
 
       parse_operator:
         FunctionStorage::Operation operation;

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -182,7 +182,10 @@ class Renderer : public NodeVisitor {
   }
 
   void visit(const DataNode& node) {
-    if (additional_data.contains(node.ptr)) {
+    if (node.ptr.empty()) {
+      // root document
+      data_eval_stack.push(data_input);
+    } else if (additional_data.contains(node.ptr)) {
       data_eval_stack.push(&(additional_data[node.ptr]));
     } else if (data_input->contains(node.ptr)) {
       data_eval_stack.push(&(*data_input)[node.ptr]);

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -299,4 +299,20 @@ $$ endif
 
     CHECK(env.render(string_template, data) == "Hello Peter\n    You really are Peter\n");
   }
+
+  SUBCASE("root document") {
+    inja::Environment env;
+    inja::json array {"item1", "item2", "item3"};
+
+    CHECK(env.render("{{.}}", array) == "[\"item1\",\"item2\",\"item3\"]");
+    CHECK(env.render("{% for item in . %}{{item}},{% endfor %}", array) == "item1,item2,item3,");
+
+    inja::json object {
+      {"name", "Peter"},
+      {"city", "Brunswick"}
+    };
+    CHECK(env.render("{{.}}", object) == "{\"city\":\"Brunswick\",\"name\":\"Peter\"}");
+    CHECK(env.render("{% for key, value in . %}{{key}} => {{value}}, {% endfor %}", object) == "city => Brunswick, name => Peter, ");
+  }
+
 }


### PR DESCRIPTION
This closes #234.

When I have a list of items (could be objects as well) in the json data file.

```json
[
    "item1", "item2","item3"
]
```

Now when trying to use them in a loop like
```
## for item in .
{{ item }}
## endfor
```

**Consideration:** Is "."  appropriate to refer the root document? If not, I'll make another pull request.
**Note:** This is ad-hoc fix. "." cannot be set as the second or later argument. It may be fixed by #247 though I have not confirmed it.
