### PR TITLE
c++17 support starts from gcc8

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Inja uses exceptions to handle ill-formed template input. However, exceptions ca
 
 Inja uses the `string_view` feature of the C++17 STL. Currently, the following compilers are tested:
 
-- GCC 7 - 11 (and possibly later)
+- GCC 8 - 11 (and possibly later)
 - Clang 5 - 12 (and possibly later)
 - Microsoft Visual C++ 2017 15.0 - 2022 (and possibly later)
 


### PR DESCRIPTION
Just fix the readme.