### PR TITLE
Set CMake policy 0077 for easy inclusion from other CMake prjs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
+# See https://cmake.org/cmake/help/latest/policy/CMP0077.html
+# This allows for setting option variables externally, when this project
+# is included in another CMake project.
+cmake_policy(SET CMP0077 NEW)
 
 project(inja LANGUAGES CXX VERSION 3.4.0)
 


### PR DESCRIPTION
When including inja in another CMake project, it is desirable to set CMake options for the inja project in the containing project. This can be done through CMake variable setting. Unfortunately, for this to work correctly, both projects need to set [CMake policy 77](https://cmake.org/cmake/help/latest/policy/CMP0077.html) to `NEW`. This pull request sets this option in the inja project to allow for easier inclusion.