### PR TITLE
Fixes the json exception when using "\\" inside a string; closes #257

### DIFF
--- a/include/inja/lexer.hpp
+++ b/include/inja/lexer.hpp
@@ -213,7 +213,7 @@ class Lexer {
       }
       const char ch = m_in[pos++];
       if (ch == '\\') {
-        escape = true;
+        escape = !escape;
       } else if (!escape && ch == m_in[tok_start]) {
         break;
       } else {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1198,7 +1198,7 @@ class Lexer {
       }
       const char ch = m_in[pos++];
       if (ch == '\\') {
-        escape = true;
+        escape = !escape;
       } else if (!escape && ch == m_in[tok_start]) {
         break;
       } else {


### PR DESCRIPTION
Fixes the exception by switching
```cpp
if (ch == '\\') {
  escape = true;
```
to
```cpp
if (ch == '\\') {
  escape = !escape;
```
in `scan_string()`.