### PR TITLE
fix: cmake does not find embedded json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if(INJA_USE_EMBEDDED_JSON)
 
     target_include_directories(nlohmann_json INTERFACE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/include>
-      $<INSTALL_INTERFACE:${INJA_INSTALL_INCLUDE_DIR}/inja/json/include>
+      $<INSTALL_INTERFACE:${INJA_INSTALL_INCLUDE_DIR}/nlohmann>
     )
 
     target_compile_features(nlohmann_json INTERFACE cxx_std_17)


### PR DESCRIPTION
The exported cmake target does not find the embedded json library, because it looks in the wrong directory. It looks in `<prefix>/include/inja/json/include` but it is actually installed into `<prefix>/include/nlohmann`. This PR simply changes the directory where cmake looks to the actual install directory.