### PR TITLE
Allow escaped json to survive rendering

### DIFF
--- a/include/inja/config.hpp
+++ b/include/inja/config.hpp
@@ -74,6 +74,7 @@ struct ParserConfig {
  */
 struct RenderConfig {
   bool throw_at_missing_includes {true};
+  bool escape_strings {};
 };
 
 } // namespace inja

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -83,6 +83,11 @@ public:
     lexer_config.lstrip_blocks = lstrip_blocks;
   }
 
+  /// Sets the config for rendering strings raw or escaped
+  void set_escape_strings(bool escape_strings) {
+      render_config.escape_strings = escape_strings;
+  }
+
   /// Sets the element notation syntax
   void set_search_included_templates_in_files(bool search_in_files) {
     parser_config.search_included_templates_in_files = search_in_files;

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -54,8 +54,17 @@ class Renderer : public NodeVisitor {
   }
 
   void print_data(const std::shared_ptr<json> value) {
-    if (value->is_string() && !config.escape_strings) {
-      *output_stream << value->get_ref<const json::string_t&>();
+    if (value->is_string()) {
+      std::string val;
+      if (config.escape_strings) {
+        val = value->dump();
+        val = val.substr(0,1) == "\"" && val.substr(val.length()-1,1) == "\""
+            ? val.substr(1, val.length()-2)
+            : val;
+      } else {
+        val = value->get_ref<const json::string_t&>();
+      }
+      *output_stream << val;
     } else if (value->is_number_integer()) {
       *output_stream << value->get<const json::number_integer_t>();
     } else if (value->is_null()) {

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -57,7 +57,11 @@ class Renderer : public NodeVisitor {
     if (value->is_string()) {
       std::string val;
       if (config.escape_strings) {
+        // get the value as a dump() to properly escape values
         val = value->dump();
+
+        // strip the leading and trailing " characters that are added by dump()
+        // if C++20 is adopted, val.starts_with and val.ends_with would clean this up a bit
         val = val.substr(0,1) == "\"" && val.substr(val.length()-1,1) == "\""
             ? val.substr(1, val.length()-2)
             : val;

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -54,7 +54,7 @@ class Renderer : public NodeVisitor {
   }
 
   void print_data(const std::shared_ptr<json> value) {
-    if (value->is_string()) {
+    if (value->is_string() && !config.escape_strings) {
       *output_stream << value->get_ref<const json::string_t&>();
     } else if (value->is_number_integer()) {
       *output_stream << value->get<const json::number_integer_t>();

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -882,6 +882,7 @@ struct ParserConfig {
  */
 struct RenderConfig {
   bool throw_at_missing_includes {true};
+  bool escape_strings {};
 };
 
 } // namespace inja
@@ -2123,7 +2124,7 @@ class Renderer : public NodeVisitor {
   }
 
   void print_data(const std::shared_ptr<json> value) {
-    if (value->is_string()) {
+    if (value->is_string() && !config.escape_strings) {
       *output_stream << value->get_ref<const json::string_t&>();
     } else if (value->is_number_integer()) {
       *output_stream << value->get<const json::number_integer_t>();
@@ -2770,6 +2771,11 @@ public:
   /// Sets whether to strip the spaces and tabs from the start of a line to a block
   void set_lstrip_blocks(bool lstrip_blocks) {
     lexer_config.lstrip_blocks = lstrip_blocks;
+  }
+
+  /// Sets the config for rendering strings raw or escaped
+  void set_escape_strings(bool escape_strings) {
+      render_config.escape_strings = escape_strings;
   }
 
   /// Sets the element notation syntax

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2124,8 +2124,17 @@ class Renderer : public NodeVisitor {
   }
 
   void print_data(const std::shared_ptr<json> value) {
-    if (value->is_string() && !config.escape_strings) {
-      *output_stream << value->get_ref<const json::string_t&>();
+    if (value->is_string()) {
+      std::string val;
+      if (config.escape_strings) {
+        val = value->dump();
+        val = val.substr(0,1) == "\"" && val.substr(val.length()-1,1) == "\""
+            ? val.substr(1, val.length()-2)
+            : val;
+      } else {
+        val = value->get_ref<const json::string_t&>();
+      }
+      *output_stream << val;
     } else if (value->is_number_integer()) {
       *output_stream << value->get<const json::number_integer_t>();
     } else if (value->is_null()) {

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -42,7 +42,7 @@ TEST_CASE("types") {
 
     CHECK(env.render(R"EOF({"Value":"{{ quoted }}"})EOF", data) == R"EOF({"Value":""quoted value""})EOF");
     env.set_escape_strings(true);
-    CHECK(env.render(R"EOF({"Value":{{ quoted }}})EOF", data) == R"EOF({"Value":"\"quoted value\""})EOF");
+    CHECK(env.render(R"EOF({"Value":"{{ quoted }}"})EOF", data) == R"EOF({"Value":"\"quoted value\""})EOF");
     env.set_escape_strings(false);
 
     CHECK_THROWS_WITH(env.render("{{unknown}}", data), "[inja.exception.render_error] (at 1:3) variable 'unknown' not found");

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -18,6 +18,7 @@ TEST_CASE("types") {
   data["relatives"]["brother"] = "Chris";
   data["relatives"]["sister"] = "Jenny";
   data["vars"] = {2, 3, 4, 0, -1, -2, -3};
+  data["quoted"] = "\"quoted value\"";
 
   SUBCASE("basic") {
     CHECK(env.render("", data) == "");
@@ -38,6 +39,11 @@ TEST_CASE("types") {
     CHECK(env.render("{{ \"{{ no_value }}\" }}", data) == "{{ no_value }}");
     CHECK(env.render("{{ @name }}", data) == "@name");
     CHECK(env.render("{{ $name }}", data) == "$name");
+
+    CHECK(env.render(R"EOF({"Value":"{{ quoted }}"})EOF", data) == R"EOF({"Value":""quoted value""})EOF");
+    env.set_escape_strings(true);
+    CHECK(env.render(R"EOF({"Value":{{ quoted }}})EOF", data) == R"EOF({"Value":"\"quoted value\""})EOF");
+    env.set_escape_strings(false);
 
     CHECK_THROWS_WITH(env.render("{{unknown}}", data), "[inja.exception.render_error] (at 1:3) variable 'unknown' not found");
   }


### PR DESCRIPTION
Add option to .dump() strings instead of .get<std::string>().

this is useful in cases where the output of the rendered template is expected to be valid JSON. For example:
Input: 
```json
{
  "foo": "\"bar\""
}
```
Template:
```
{
  "FOO": "{{ foo }}"
}
```
Output (without allowing escaped strings):
```json
{
  "FOO": ""bar""
}
```
Output (allowing escaped strings):
```json
{
  "FOO": "\"bar\""
}
```