### PR TITLE
Fix not rendering uint64_t values greater than the int64_t max value

### DIFF
--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -56,6 +56,8 @@ class Renderer : public NodeVisitor {
   void print_data(const std::shared_ptr<json> value) {
     if (value->is_string()) {
       *output_stream << value->get_ref<const json::string_t&>();
+    } else if (value->is_number_unsigned()) {
+      *output_stream << value->get<const json::number_unsigned_t>();
     } else if (value->is_number_integer()) {
       *output_stream << value->get<const json::number_integer_t>();
     } else if (value->is_null()) {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2125,6 +2125,8 @@ class Renderer : public NodeVisitor {
   void print_data(const std::shared_ptr<json> value) {
     if (value->is_string()) {
       *output_stream << value->get_ref<const json::string_t&>();
+    } else if (value->is_number_unsigned()) {
+      *output_stream << value->get<const json::number_unsigned_t>();
     } else if (value->is_number_integer()) {
       *output_stream << value->get<const json::number_integer_t>();
     } else if (value->is_null()) {

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -18,6 +18,7 @@ TEST_CASE("types") {
   data["relatives"]["brother"] = "Chris";
   data["relatives"]["sister"] = "Jenny";
   data["vars"] = {2, 3, 4, 0, -1, -2, -3};
+  data["max_value"] = 18446744073709551615ull;
 
   SUBCASE("basic") {
     CHECK(env.render("", data) == "");
@@ -55,6 +56,7 @@ TEST_CASE("types") {
                      "false %}, {% endif %}{% endfor %}",
                      data) == "1: brother: Chris, 2: mother: Maria, 3: sister: Jenny");
     CHECK(env.render("{% for v in vars %}{% if v > 0 %}+{% endif %}{% endfor %}", data) == "+++");
+    CHECK(env.render("{{max_value}}", data) == "18446744073709551615");
     CHECK(env.render("{% for name in names %}{{ loop.index }}: {{ name }}{% if not loop.is_last %}, {% endif %}{% endfor %}!", data) == "0: Jeff, 1: Seb!");
     CHECK(env.render("{% for name in names %}{{ loop.index }}: {{ name }}{% if loop.is_last == false %}, {% endif %}{% "
                      "endfor %}!",

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -39,6 +39,7 @@ TEST_CASE("types") {
     CHECK(env.render("{{ \"{{ no_value }}\" }}", data) == "{{ no_value }}");
     CHECK(env.render("{{ @name }}", data) == "@name");
     CHECK(env.render("{{ $name }}", data) == "$name");
+    CHECK(env.render("{{max_value}}", data) == "18446744073709551615");
 
     CHECK_THROWS_WITH(env.render("{{unknown}}", data), "[inja.exception.render_error] (at 1:3) variable 'unknown' not found");
   }
@@ -56,7 +57,6 @@ TEST_CASE("types") {
                      "false %}, {% endif %}{% endfor %}",
                      data) == "1: brother: Chris, 2: mother: Maria, 3: sister: Jenny");
     CHECK(env.render("{% for v in vars %}{% if v > 0 %}+{% endif %}{% endfor %}", data) == "+++");
-    CHECK(env.render("{{max_value}}", data) == "18446744073709551615");
     CHECK(env.render("{% for name in names %}{{ loop.index }}: {{ name }}{% if not loop.is_last %}, {% endif %}{% endfor %}!", data) == "0: Jeff, 1: Seb!");
     CHECK(env.render("{% for name in names %}{{ loop.index }}: {{ name }}{% if loop.is_last == false %}, {% endif %}{% "
                      "endfor %}!",


### PR DESCRIPTION
Values greater than the maximum positive value for int64_t do not render correctly -- they are rendered as negative values instead of positive values. This change fixes how unsigned integers are printed in the renderer.