### PR TITLE
clang-tidy applied and CMake installation of the single header added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(inja LANGUAGES CXX VERSION 3.4.0)
 
 option(INJA_USE_EMBEDDED_JSON "Use the shipped json header if not available on the system" ON)
 option(INJA_INSTALL "Generate install targets for inja" ON)
+option(INJA_INSTALL_SINGLE_HEADER "Install the single header instead" OFF)
 option(INJA_EXPORT "Export the current build tree to the package registry" ON)
 option(BUILD_TESTING "Build unit tests" ON)
 option(INJA_BUILD_TESTS "Build unit tests when BUILD_TESTING is enabled." ON)
@@ -166,11 +167,20 @@ if(INJA_INSTALL)
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
   )
 
-  install(
-    DIRECTORY include/inja
-    DESTINATION ${INJA_INSTALL_INCLUDE_DIR}
-    FILES_MATCHING PATTERN "*.hpp"
-  )
+  if(INJA_INSTALL_SINGLE_HEADER)
+    install(
+      DIRECTORY single_include/inja
+      DESTINATION ${INJA_INSTALL_INCLUDE_DIR}
+      FILES_MATCHING PATTERN "*.hpp"
+    )
+  else()
+    install(
+      DIRECTORY include/inja
+      DESTINATION ${INJA_INSTALL_INCLUDE_DIR}
+      FILES_MATCHING PATTERN "*.hpp"
+    )
+  endif()
+
   if(INJA_USE_EMBEDDED_JSON)
     install(
       DIRECTORY third_party/include/nlohmann
@@ -178,6 +188,7 @@ if(INJA_INSTALL)
       FILES_MATCHING PATTERN "*.hpp"
     )
   endif()
+
   install(
     FILES
       "${CMAKE_CURRENT_BINARY_DIR}/${INJA_CONFIG_PATH}/injaConfig.cmake"

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -3,17 +3,16 @@
 
 #include <fstream>
 #include <iostream>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <string_view>
 
 #include "config.hpp"
 #include "function_storage.hpp"
+#include "inja.hpp"
 #include "parser.hpp"
 #include "renderer.hpp"
 #include "template.hpp"
-#include "utils.hpp"
 
 namespace inja {
 

--- a/include/inja/exceptions.hpp
+++ b/include/inja/exceptions.hpp
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_INJA_EXCEPTIONS_HPP_
 #define INCLUDE_INJA_EXCEPTIONS_HPP_
 
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 

--- a/include/inja/function_storage.hpp
+++ b/include/inja/function_storage.hpp
@@ -1,8 +1,14 @@
 #ifndef INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 #define INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 
+#include <functional>
+#include <map>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
+
+#include "inja.hpp"
 
 namespace inja {
 

--- a/include/inja/lexer.hpp
+++ b/include/inja/lexer.hpp
@@ -2,9 +2,12 @@
 #define INCLUDE_INJA_LEXER_HPP_
 
 #include <cctype>
-#include <locale>
+#include <cstddef>
+#include <string>
+#include <string_view>
 
 #include "config.hpp"
+#include "exceptions.hpp"
 #include "token.hpp"
 #include "utils.hpp"
 
@@ -311,7 +314,7 @@ public:
       pos += open_start;
 
       // try to match one of the opening sequences, and get the close
-      std::string_view open_str = m_in.substr(pos);
+      const std::string_view open_str = m_in.substr(pos);
       bool must_lstrip = false;
       if (inja::string_view::starts_with(open_str, config.expression_open)) {
         if (inja::string_view::starts_with(open_str, config.expression_open_force_lstrip)) {

--- a/include/inja/lexer.hpp
+++ b/include/inja/lexer.hpp
@@ -3,7 +3,6 @@
 
 #include <cctype>
 #include <cstddef>
-#include <string>
 #include <string_view>
 
 #include "config.hpp"

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -1,11 +1,15 @@
 #ifndef INCLUDE_INJA_NODE_HPP_
 #define INCLUDE_INJA_NODE_HPP_
 
+#include <cstddef>
+#include <memory>
 #include <string>
 #include <string_view>
-#include <utility>
+#include <tuple>
+#include <vector>
 
 #include "function_storage.hpp"
+#include "inja.hpp"
 #include "utils.hpp"
 
 namespace inja {

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -1,20 +1,24 @@
 #ifndef INCLUDE_INJA_PARSER_HPP_
 #define INCLUDE_INJA_PARSER_HPP_
 
-#include <limits>
+#include <cstddef>
+#include <fstream>
+#include <iterator>
+#include <memory>
 #include <stack>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 #include "config.hpp"
 #include "exceptions.hpp"
 #include "function_storage.hpp"
+#include "inja.hpp"
 #include "lexer.hpp"
 #include "node.hpp"
 #include "template.hpp"
 #include "token.hpp"
-#include "utils.hpp"
 
 namespace inja {
 
@@ -64,7 +68,7 @@ class Parser {
   }
 
   inline void add_literal(Arguments &arguments, const char* content_ptr) {
-    std::string_view data_text(literal_start.data(), tok.text.data() - literal_start.data() + tok.text.size());
+    const std::string_view data_text(literal_start.data(), tok.text.data() - literal_start.data() + tok.text.size());
     arguments.emplace_back(std::make_shared<LiteralNode>(data_text, data_text.data() - content_ptr));
   }
 
@@ -88,8 +92,8 @@ class Parser {
       return;
     }
 
-    std::string original_path = static_cast<std::string>(path);
-    std::string original_name = template_name;
+    const std::string original_path = static_cast<std::string>(path);
+    const std::string original_name = template_name;
 
     if (config.search_included_templates_in_files) {
       // Build the relative path
@@ -103,7 +107,7 @@ class Parser {
         std::ifstream file;
         file.open(template_name);
         if (!file.fail()) {
-          std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+          const std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
 
           auto include_template = Template(text);
           template_storage.emplace(template_name, include_template);
@@ -472,7 +476,7 @@ class Parser {
           throw_parser_error("expected id, got '" + tok.describe() + "'");
         }
 
-        Token key_token = std::move(value_token);
+        const Token key_token = std::move(value_token);
         value_token = tok;
         get_next_token();
 
@@ -533,7 +537,7 @@ class Parser {
         throw_parser_error("expected variable name, got '" + tok.describe() + "'");
       }
 
-      std::string key = static_cast<std::string>(tok.text);
+      const std::string key = static_cast<std::string>(tok.text);
       get_next_token();
 
       auto set_statement_node = std::make_shared<SetStatementNode>(key, tok.text.data() - tmpl.content.c_str());
@@ -627,7 +631,7 @@ public:
   }
 
   void parse_into_template(Template& tmpl, std::string_view filename) {
-    std::string_view path = filename.substr(0, filename.find_last_of("/\\") + 1);
+    const std::string_view path = filename.substr(0, filename.find_last_of("/\\") + 1);
 
     // StringRef path = sys::path::parent_path(filename);
     auto sub_parser = Parser(config, lexer.get_config(), template_storage, function_storage);

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -2,13 +2,23 @@
 #define INCLUDE_INJA_RENDERER_HPP_
 
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <memory>
 #include <numeric>
+#include <ostream>
+#include <sstream>
+#include <stack>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "config.hpp"
 #include "exceptions.hpp"
+#include "function_storage.hpp"
+#include "inja.hpp"
 #include "node.hpp"
 #include "template.hpp"
 #include "utils.hpp"
@@ -53,7 +63,7 @@ class Renderer : public NodeVisitor {
     return !data->empty();
   }
 
-  void print_data(const std::shared_ptr<json> value) {
+  void print_data(const std::shared_ptr<json>& value) {
     if (value->is_string()) {
       *output_stream << value->get_ref<const json::string_t&>();
     } else if (value->is_number_unsigned()) {
@@ -87,7 +97,7 @@ class Renderer : public NodeVisitor {
         throw_renderer_error("expression could not be evaluated", expression_list);
       }
 
-      auto node = not_found_stack.top();
+      const auto node = not_found_stack.top();
       not_found_stack.pop();
 
       throw_renderer_error("variable '" + static_cast<std::string>(node->name) + "' not found", *node);
@@ -96,7 +106,7 @@ class Renderer : public NodeVisitor {
   }
 
   void throw_renderer_error(const std::string& message, const AstNode& node) {
-    SourceLocation loc = get_source_location(current_template->content, node.pos);
+    const SourceLocation loc = get_source_location(current_template->content, node.pos);
     INJA_THROW(RenderError(message, loc));
   }
 
@@ -138,7 +148,7 @@ class Renderer : public NodeVisitor {
 
   template <bool throw_not_found = true> Arguments get_argument_vector(const FunctionNode& node) {
     const size_t N = node.arguments.size();
-    for (auto a : node.arguments) {
+    for (const auto& a : node.arguments) {
       a->accept(*this);
     }
 
@@ -164,7 +174,7 @@ class Renderer : public NodeVisitor {
   }
 
   void visit(const BlockNode& node) {
-    for (auto& n : node.nodes) {
+    for (const auto& n : node.nodes) {
       n->accept(*this);
 
       if (break_rendering) {

--- a/include/inja/statistics.hpp
+++ b/include/inja/statistics.hpp
@@ -10,7 +10,7 @@ namespace inja {
  */
 class StatisticsVisitor : public NodeVisitor {
   void visit(const BlockNode& node) {
-    for (auto& n : node.nodes) {
+    for (const auto& n : node.nodes) {
       n->accept(*this);
     }
   }
@@ -24,7 +24,7 @@ class StatisticsVisitor : public NodeVisitor {
   }
 
   void visit(const FunctionNode& node) {
-    for (auto& n : node.arguments) {
+    for (const auto& n : node.arguments) {
       n->accept(*this);
     }
   }

--- a/include/inja/template.hpp
+++ b/include/inja/template.hpp
@@ -4,7 +4,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "node.hpp"
 #include "statistics.hpp"
@@ -23,7 +22,7 @@ struct Template {
   explicit Template(const std::string& content): content(content) {}
 
   /// Return number of variables (total number, not distinct ones) in the template
-  int count_variables() {
+  int count_variables() const {
     auto statistic_visitor = StatisticsVisitor();
     root.accept(statistic_visitor);
     return statistic_visitor.variable_counter;

--- a/include/inja/utils.hpp
+++ b/include/inja/utils.hpp
@@ -2,7 +2,7 @@
 #define INCLUDE_INJA_UTILS_HPP_
 
 #include <algorithm>
-#include <fstream>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -19,7 +19,7 @@ inline std::string_view slice(std::string_view view, size_t start, size_t end) {
 }
 
 inline std::pair<std::string_view, std::string_view> split(std::string_view view, char Separator) {
-  size_t idx = view.find(Separator);
+  const size_t idx = view.find(Separator);
   if (idx == std::string_view::npos) {
     return std::make_pair(view, std::string_view());
   }
@@ -34,7 +34,7 @@ inline bool starts_with(std::string_view view, std::string_view prefix) {
 inline SourceLocation get_source_location(std::string_view content, size_t pos) {
   // Get line and offset position (starts at 1:1)
   auto sliced = string_view::slice(content, 0, pos);
-  std::size_t last_newline = sliced.rfind("\n");
+  const std::size_t last_newline = sliced.rfind('\n');
 
   if (last_newline == std::string_view::npos) {
     return {1, sliced.length() + 1};
@@ -44,7 +44,7 @@ inline SourceLocation get_source_location(std::string_view content, size_t pos) 
   size_t count_lines = 0;
   size_t search_start = 0;
   while (search_start <= sliced.size()) {
-    search_start = sliced.find("\n", search_start) + 1;
+    search_start = sliced.find('\n', search_start) + 1;
     if (search_start == 0) {
       break;
     }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -57,7 +57,6 @@ using json = INJA_DATA_TYPE;
 
 #include <fstream>
 #include <iostream>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -76,22 +75,31 @@ using json = INJA_DATA_TYPE;
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 // #include "node.hpp"
 #ifndef INCLUDE_INJA_NODE_HPP_
 #define INCLUDE_INJA_NODE_HPP_
 
+#include <cstddef>
+#include <memory>
 #include <string>
 #include <string_view>
-#include <utility>
+#include <tuple>
+#include <vector>
 
 // #include "function_storage.hpp"
 #ifndef INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 #define INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 
+#include <functional>
+#include <map>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
+
+// #include "inja.hpp"
+
 
 namespace inja {
 
@@ -225,12 +233,14 @@ public:
 
 #endif // INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 
+// #include "inja.hpp"
+
 // #include "utils.hpp"
 #ifndef INCLUDE_INJA_UTILS_HPP_
 #define INCLUDE_INJA_UTILS_HPP_
 
 #include <algorithm>
-#include <fstream>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -239,6 +249,7 @@ public:
 #ifndef INCLUDE_INJA_EXCEPTIONS_HPP_
 #define INCLUDE_INJA_EXCEPTIONS_HPP_
 
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 
@@ -295,7 +306,7 @@ inline std::string_view slice(std::string_view view, size_t start, size_t end) {
 }
 
 inline std::pair<std::string_view, std::string_view> split(std::string_view view, char Separator) {
-  size_t idx = view.find(Separator);
+  const size_t idx = view.find(Separator);
   if (idx == std::string_view::npos) {
     return std::make_pair(view, std::string_view());
   }
@@ -310,7 +321,7 @@ inline bool starts_with(std::string_view view, std::string_view prefix) {
 inline SourceLocation get_source_location(std::string_view content, size_t pos) {
   // Get line and offset position (starts at 1:1)
   auto sliced = string_view::slice(content, 0, pos);
-  std::size_t last_newline = sliced.rfind("\n");
+  const std::size_t last_newline = sliced.rfind('\n');
 
   if (last_newline == std::string_view::npos) {
     return {1, sliced.length() + 1};
@@ -320,7 +331,7 @@ inline SourceLocation get_source_location(std::string_view content, size_t pos) 
   size_t count_lines = 0;
   size_t search_start = 0;
   while (search_start <= sliced.size()) {
-    search_start = sliced.find("\n", search_start) + 1;
+    search_start = sliced.find('\n', search_start) + 1;
     if (search_start == 0) {
       break;
     }
@@ -723,7 +734,7 @@ namespace inja {
  */
 class StatisticsVisitor : public NodeVisitor {
   void visit(const BlockNode& node) {
-    for (auto& n : node.nodes) {
+    for (const auto& n : node.nodes) {
       n->accept(*this);
     }
   }
@@ -737,7 +748,7 @@ class StatisticsVisitor : public NodeVisitor {
   }
 
   void visit(const FunctionNode& node) {
-    for (auto& n : node.arguments) {
+    for (const auto& n : node.arguments) {
       n->accept(*this);
     }
   }
@@ -800,7 +811,7 @@ struct Template {
   explicit Template(const std::string& content): content(content) {}
 
   /// Return number of variables (total number, not distinct ones) in the template
-  int count_variables() {
+  int count_variables() const {
     auto statistic_visitor = StatisticsVisitor();
     root.accept(statistic_visitor);
     return statistic_visitor.variable_counter;
@@ -890,13 +901,19 @@ struct RenderConfig {
 
 // #include "function_storage.hpp"
 
+// #include "inja.hpp"
+
 // #include "parser.hpp"
 #ifndef INCLUDE_INJA_PARSER_HPP_
 #define INCLUDE_INJA_PARSER_HPP_
 
-#include <limits>
+#include <cstddef>
+#include <fstream>
+#include <iterator>
+#include <memory>
 #include <stack>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -906,14 +923,20 @@ struct RenderConfig {
 
 // #include "function_storage.hpp"
 
+// #include "inja.hpp"
+
 // #include "lexer.hpp"
 #ifndef INCLUDE_INJA_LEXER_HPP_
 #define INCLUDE_INJA_LEXER_HPP_
 
 #include <cctype>
-#include <locale>
+#include <cstddef>
+#include <string>
+#include <string_view>
 
 // #include "config.hpp"
+
+// #include "exceptions.hpp"
 
 // #include "token.hpp"
 #ifndef INCLUDE_INJA_TOKEN_HPP_
@@ -1296,7 +1319,7 @@ public:
       pos += open_start;
 
       // try to match one of the opening sequences, and get the close
-      std::string_view open_str = m_in.substr(pos);
+      const std::string_view open_str = m_in.substr(pos);
       bool must_lstrip = false;
       if (inja::string_view::starts_with(open_str, config.expression_open)) {
         if (inja::string_view::starts_with(open_str, config.expression_open_force_lstrip)) {
@@ -1425,8 +1448,6 @@ public:
 
 // #include "token.hpp"
 
-// #include "utils.hpp"
-
 
 namespace inja {
 
@@ -1476,7 +1497,7 @@ class Parser {
   }
 
   inline void add_literal(Arguments &arguments, const char* content_ptr) {
-    std::string_view data_text(literal_start.data(), tok.text.data() - literal_start.data() + tok.text.size());
+    const std::string_view data_text(literal_start.data(), tok.text.data() - literal_start.data() + tok.text.size());
     arguments.emplace_back(std::make_shared<LiteralNode>(data_text, data_text.data() - content_ptr));
   }
 
@@ -1500,8 +1521,8 @@ class Parser {
       return;
     }
 
-    std::string original_path = static_cast<std::string>(path);
-    std::string original_name = template_name;
+    const std::string original_path = static_cast<std::string>(path);
+    const std::string original_name = template_name;
 
     if (config.search_included_templates_in_files) {
       // Build the relative path
@@ -1515,7 +1536,7 @@ class Parser {
         std::ifstream file;
         file.open(template_name);
         if (!file.fail()) {
-          std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+          const std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
 
           auto include_template = Template(text);
           template_storage.emplace(template_name, include_template);
@@ -1884,7 +1905,7 @@ class Parser {
           throw_parser_error("expected id, got '" + tok.describe() + "'");
         }
 
-        Token key_token = std::move(value_token);
+        const Token key_token = std::move(value_token);
         value_token = tok;
         get_next_token();
 
@@ -1945,7 +1966,7 @@ class Parser {
         throw_parser_error("expected variable name, got '" + tok.describe() + "'");
       }
 
-      std::string key = static_cast<std::string>(tok.text);
+      const std::string key = static_cast<std::string>(tok.text);
       get_next_token();
 
       auto set_statement_node = std::make_shared<SetStatementNode>(key, tok.text.data() - tmpl.content.c_str());
@@ -2039,7 +2060,7 @@ public:
   }
 
   void parse_into_template(Template& tmpl, std::string_view filename) {
-    std::string_view path = filename.substr(0, filename.find_last_of("/\\") + 1);
+    const std::string_view path = filename.substr(0, filename.find_last_of("/\\") + 1);
 
     // StringRef path = sys::path::parent_path(filename);
     auto sub_parser = Parser(config, lexer.get_config(), template_storage, function_storage);
@@ -2066,7 +2087,15 @@ public:
 #define INCLUDE_INJA_RENDERER_HPP_
 
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <memory>
 #include <numeric>
+#include <ostream>
+#include <sstream>
+#include <stack>
 #include <string>
 #include <utility>
 #include <vector>
@@ -2074,6 +2103,10 @@ public:
 // #include "config.hpp"
 
 // #include "exceptions.hpp"
+
+// #include "function_storage.hpp"
+
+// #include "inja.hpp"
 
 // #include "node.hpp"
 
@@ -2122,7 +2155,7 @@ class Renderer : public NodeVisitor {
     return !data->empty();
   }
 
-  void print_data(const std::shared_ptr<json> value) {
+  void print_data(const std::shared_ptr<json>& value) {
     if (value->is_string()) {
       *output_stream << value->get_ref<const json::string_t&>();
     } else if (value->is_number_unsigned()) {
@@ -2156,7 +2189,7 @@ class Renderer : public NodeVisitor {
         throw_renderer_error("expression could not be evaluated", expression_list);
       }
 
-      auto node = not_found_stack.top();
+      const auto node = not_found_stack.top();
       not_found_stack.pop();
 
       throw_renderer_error("variable '" + static_cast<std::string>(node->name) + "' not found", *node);
@@ -2165,7 +2198,7 @@ class Renderer : public NodeVisitor {
   }
 
   void throw_renderer_error(const std::string& message, const AstNode& node) {
-    SourceLocation loc = get_source_location(current_template->content, node.pos);
+    const SourceLocation loc = get_source_location(current_template->content, node.pos);
     INJA_THROW(RenderError(message, loc));
   }
 
@@ -2207,7 +2240,7 @@ class Renderer : public NodeVisitor {
 
   template <bool throw_not_found = true> Arguments get_argument_vector(const FunctionNode& node) {
     const size_t N = node.arguments.size();
-    for (auto a : node.arguments) {
+    for (const auto& a : node.arguments) {
       a->accept(*this);
     }
 
@@ -2233,7 +2266,7 @@ class Renderer : public NodeVisitor {
   }
 
   void visit(const BlockNode& node) {
-    for (auto& n : node.nodes) {
+    for (const auto& n : node.nodes) {
       n->accept(*this);
 
       if (break_rendering) {
@@ -2702,8 +2735,6 @@ public:
 #endif // INCLUDE_INJA_RENDERER_HPP_
 
 // #include "template.hpp"
-
-// #include "utils.hpp"
 
 
 namespace inja {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -931,7 +931,6 @@ struct RenderConfig {
 
 #include <cctype>
 #include <cstddef>
-#include <string>
 #include <string_view>
 
 // #include "config.hpp"

--- a/test/test-files.cpp
+++ b/test/test-files.cpp
@@ -1,5 +1,10 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
+#include <doctest/doctest.h>
+
+#include "inja/environment.hpp"
+#include "inja/inja.hpp"
+
 TEST_CASE("loading") {
   inja::Environment env;
   inja::json data;

--- a/test/test-functions.cpp
+++ b/test/test-functions.cpp
@@ -1,5 +1,11 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
+#include <doctest/doctest.h>
+#include <string>
+
+#include "inja/environment.hpp"
+#include "inja/inja.hpp"
+
 TEST_CASE("functions") {
   inja::Environment env;
 

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -1,5 +1,12 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
+#include <doctest/doctest.h>
+#include <string>
+
+#include "inja/environment.hpp"
+#include "inja/inja.hpp"
+#include "inja/template.hpp"
+
 TEST_CASE("types") {
   inja::Environment env;
   inja::json data;
@@ -160,7 +167,7 @@ TEST_CASE("templates") {
 
   SUBCASE("reuse") {
     inja::Environment env;
-    inja::Template temp = env.parse("{% if is_happy %}{{ name }}{% else %}{{ city }}{% endif %}");
+    const inja::Template temp = env.parse("{% if is_happy %}{{ name }}{% else %}{{ city }}{% endif %}");
 
     CHECK(env.render(temp, data) == "Peter");
 
@@ -171,10 +178,10 @@ TEST_CASE("templates") {
 
   SUBCASE("include") {
     inja::Environment env;
-    inja::Template t1 = env.parse("Hello {{ name }}");
+    const inja::Template t1 = env.parse("Hello {{ name }}");
     env.include_template("greeting", t1);
 
-    inja::Template t2 = env.parse("{% include \"greeting\" %}!");
+    const inja::Template t2 = env.parse("{% include \"greeting\" %}!");
     CHECK(env.render(t2, data) == "Hello Peter!");
     CHECK_THROWS_WITH(env.parse("{% include \"does-not-exist\" %}!"), "[inja.exception.file_error] failed accessing file at 'does-not-exist'");
 
@@ -189,13 +196,13 @@ TEST_CASE("templates") {
     env.set_search_included_templates_in_files(false);
     env.set_include_callback([&env](const std::string&, const std::string&) { return env.parse("Hello {{ name }}"); });
 
-    inja::Template t1 = env.parse("{% include \"greeting\" %}!");
+    const inja::Template t1 = env.parse("{% include \"greeting\" %}!");
     CHECK(env.render(t1, data) == "Hello Peter!");
 
     env.set_search_included_templates_in_files(true);
     env.set_include_callback([&env](const std::string&, const std::string& name) { return env.parse("Bye " + name); });
 
-    inja::Template t2 = env.parse("{% include \"Jeff\" %}!");
+    const inja::Template t2 = env.parse("{% include \"Jeff\" %}!");
     CHECK(env.render(t2, data) == "Bye Jeff!");
   }
 
@@ -211,9 +218,9 @@ TEST_CASE("templates") {
 
   SUBCASE("count variables") {
     inja::Environment env;
-    inja::Template t1 = env.parse("Hello {{ name }}");
-    inja::Template t2 = env.parse("{% if is_happy %}{{ name }}{% else %}{{ city }}{% endif %}");
-    inja::Template t3 = env.parse("{% if at(name, test) %}{{ name }}{% else %}{{ city }}{{ upper(city) }}{% endif %}");
+    const inja::Template t1 = env.parse("Hello {{ name }}");
+    const inja::Template t2 = env.parse("{% if is_happy %}{{ name }}{% else %}{{ city }}{% endif %}");
+    const inja::Template t3 = env.parse("{% if at(name, test) %}{{ name }}{% else %}{{ city }}{{ upper(city) }}{% endif %}");
 
     CHECK(t1.count_variables() == 1);
     CHECK(t2.count_variables() == 3);

--- a/test/test-units.cpp
+++ b/test/test-units.cpp
@@ -1,5 +1,13 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
+#include <doctest/doctest.h>
+#include <string>
+
+#include "inja/environment.hpp"
+#include "inja/function_storage.hpp"
+#include "inja/inja.hpp"
+#include "inja/utils.hpp"
+
 TEST_CASE("source location") {
   std::string content = R""""(Lorem Ipsum
   Dolor
@@ -42,7 +50,7 @@ TEST_CASE("copy environment") {
   CHECK(copy.render(test_tpl, inja::json()) == "4");
 
   // overwrite template in source env
-  inja::Template t2 = env.parse("{{ double(4) }}");
+  const inja::Template t2 = env.parse("{{ double(4) }}");
   env.include_template("tpl", t2);
   REQUIRE(env.render(test_tpl, inja::json()) == "8");
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,7 +2,7 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #define JSON_NO_IO 1


### PR DESCRIPTION
The commit messages already describe it.

The first commit does minor fixes suggested by clang-tidy which includes changing the headers. There are still many recommendation left but would require too much change which the owner needs to decide.

The second commit adds an installation of the single header. The problem is that headers like `<inja/environment.hpp>` themselves cannot be included because headers are missing. The library only works when including `<inja/inja.hpp>` or the single header.

All tests pass.

The project structure is really odd in a way that it does not include dependencies as headers but assumes that they are resolved by headers that include them which breaks the source code when the original files like `<inja/environment.hpp>`  are included directly. I tried to solve this but then you will end up with circular dependencies. This should really change.

I am the packager for the [AUR](https://aur.archlinux.org/packages/inja) and these commits are needed so I would be very greatful if this gets approved.

Grüße aus Deutschland nach Deutschland.