### PR TITLE
Fix dangling reference in parser::Parse

### DIFF
--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -29,6 +29,7 @@ class Parser {
 
   Lexer lexer;
   TemplateStorage& template_storage;
+  std::vector<Template> template_stash;
   const FunctionStorage& function_storage;
 
   Token tok, peek_tok;
@@ -621,7 +622,7 @@ public:
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
   Template parse(std::string_view input, std::string_view path) {
-    auto result = Template(static_cast<std::string>(input));
+    auto& result = template_stash.emplace_back(Template(static_cast<std::string>(input)));
     parse_into(result, path);
     return result;
   }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1441,6 +1441,7 @@ class Parser {
 
   Lexer lexer;
   TemplateStorage& template_storage;
+  std::vector<Template> template_stash;
   const FunctionStorage& function_storage;
 
   Token tok, peek_tok;
@@ -2033,7 +2034,7 @@ public:
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
   Template parse(std::string_view input, std::string_view path) {
-    auto result = Template(static_cast<std::string>(input));
+    auto& result = template_stash.emplace_back(Template(static_cast<std::string>(input)));
     parse_into(result, path);
     return result;
   }


### PR DESCRIPTION
clang static analysis is identifying the following issue:
```log
warning: Address of stack memory associated with local variable 'result' is still referred to by the stack variable 'parser' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]
```

This PR corrects that dangling reference by storing the created template on the parser before returning.