### PR TITLE
Add HTML autoescape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,16 @@ jobs:
             os: windows-2022
             compiler: msvc
 
-          - name: macOS-11-gcc
-            os: macOS-11
+          - name: macOS-12-gcc
+            os: macOS-12
             compiler: gcc
-
-          - name: macOS-11-clang
-            os: macOS-11
-            compiler: clang
 
           - name: macOS-12-clang
             os: macOS-12
+            compiler: clang
+
+          - name: macOS-14-clang
+            os: macOS-14
             compiler: clang
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
             os: macOS-12
             compiler: clang
 
-          - name: macOS-14-clang
-            os: macOS-14
-            compiler: clang
+          # - name: macOS-14-clang
+          #   os: macOS-14
+          #   compiler: clang
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -110,7 +110,16 @@ env.set_expression("{{", "}}"); // Expressions
 env.set_comment("{#", "#}"); // Comments
 env.set_statement("{%", "%}"); // Statements {% %} for many things, see below
 env.set_line_statement("##"); // Line statements ## (just an opener)
+env.set_html_autoescape(true); // Perform HTML escaping on all strings
 ```
+
+### HTML escaping
+Templates are frequently used to creat HTML pages. Source data that contains
+characters that have meaning within HTML (like <. >, &) needs to be escaped.
+It is often inconvenient to perform such escaping within the JSON data.
+
+With Environment::set_html_autoescape(true), Inja can be configured to
+HTML escape each and every string created.
 
 ### Variables
 

--- a/README.md
+++ b/README.md
@@ -113,14 +113,6 @@ env.set_line_statement("##"); // Line statements ## (just an opener)
 env.set_html_autoescape(true); // Perform HTML escaping on all strings
 ```
 
-### HTML escaping
-Templates are frequently used to creat HTML pages. Source data that contains
-characters that have meaning within HTML (like <. >, &) needs to be escaped.
-It is often inconvenient to perform such escaping within the JSON data.
-
-With Environment::set_html_autoescape(true), Inja can be configured to
-HTML escape each and every string created.
-
 ### Variables
 
 Variables are rendered within the `{{ ... }}` expressions.
@@ -372,6 +364,13 @@ render("{% if neighbour in guests -%}   I was there{% endif -%}   !", data); // 
 ```
 
 Stripping behind a statement or expression also removes any newlines.
+
+### HTML escaping
+
+Templates are frequently used to creat HTML pages. Source data that contains
+characters that have meaning within HTML (like <. >, &) needs to be escaped.
+It is often inconvenient to perform such escaping within the JSON data. With `Environment::set_html_autoescape(true)`, Inja can be configured to
+HTML escape each and every string created.
 
 ### Comments
 

--- a/include/inja/config.hpp
+++ b/include/inja/config.hpp
@@ -74,6 +74,7 @@ struct ParserConfig {
  */
 struct RenderConfig {
   bool throw_at_missing_includes {true};
+  bool html_autoescape {false};
 };
 
 } // namespace inja

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -160,6 +160,10 @@ public:
     return os;
   }
 
+  std::ostream& render_to(std::ostream& os, const std::string_view input, const json& data) {
+    return render_to(os, parse(input), data);
+  }
+
   std::string load_file(const std::string& filename) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
     return Parser::load_file(input_path + filename);

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -93,6 +93,11 @@ public:
     render_config.throw_at_missing_includes = will_throw;
   }
 
+  /// Sets whether we'll automatically perform HTML escape
+  void set_html_autoescape(bool will_escape) {
+    render_config.html_autoescape = will_escape;
+  }
+
   Template parse(std::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
     return parser.parse(input, input_path);

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -53,9 +53,30 @@ class Renderer : public NodeVisitor {
     return !data->empty();
   }
 
+
+  static std::string htmlescape(const std::string& data)
+  {
+    std::string buffer;
+    buffer.reserve(1.1*data.size());
+    for(size_t pos = 0; pos != data.size(); ++pos) {
+        switch(data[pos]) {
+            case '&':  buffer.append("&amp;");       break;
+            case '\"': buffer.append("&quot;");      break;
+            case '\'': buffer.append("&apos;");      break;
+            case '<':  buffer.append("&lt;");        break;
+            case '>':  buffer.append("&gt;");        break;
+            default:   buffer.append(&data[pos], 1); break;
+        }
+    }
+    return buffer;
+  }
+
   void print_data(const std::shared_ptr<json> value) {
     if (value->is_string()) {
-      *output_stream << value->get_ref<const json::string_t&>();
+      if(config.html_autoescape)
+	*output_stream << htmlescape(value->get_ref<const json::string_t&>());
+      else
+	*output_stream << value->get_ref<const json::string_t&>();
     } else if (value->is_number_unsigned()) {
       *output_stream << value->get<const json::number_unsigned_t>();
     } else if (value->is_number_integer()) {

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -53,30 +53,29 @@ class Renderer : public NodeVisitor {
     return !data->empty();
   }
 
-
-  static std::string htmlescape(const std::string& data)
-  {
+  static std::string htmlescape(const std::string& data) {
     std::string buffer;
-    buffer.reserve(1.1*data.size());
-    for(size_t pos = 0; pos != data.size(); ++pos) {
-        switch(data[pos]) {
-            case '&':  buffer.append("&amp;");       break;
-            case '\"': buffer.append("&quot;");      break;
-            case '\'': buffer.append("&apos;");      break;
-            case '<':  buffer.append("&lt;");        break;
-            case '>':  buffer.append("&gt;");        break;
-            default:   buffer.append(&data[pos], 1); break;
-        }
+    buffer.reserve(1.1 * data.size());
+    for (size_t pos = 0; pos != data.size(); ++pos) {
+      switch (data[pos]) {
+        case '&':  buffer.append("&amp;");       break;
+        case '\"': buffer.append("&quot;");      break;
+        case '\'': buffer.append("&apos;");      break;
+        case '<':  buffer.append("&lt;");        break;
+        case '>':  buffer.append("&gt;");        break;
+        default:   buffer.append(&data[pos], 1); break;
+      }
     }
     return buffer;
   }
 
   void print_data(const std::shared_ptr<json> value) {
     if (value->is_string()) {
-      if(config.html_autoescape)
-	*output_stream << htmlescape(value->get_ref<const json::string_t&>());
-      else
-	*output_stream << value->get_ref<const json::string_t&>();
+      if (config.html_autoescape) {
+        *output_stream << htmlescape(value->get_ref<const json::string_t&>());
+      } else {
+        *output_stream << value->get_ref<const json::string_t&>();
+      }
     } else if (value->is_number_unsigned()) {
       *output_stream << value->get<const json::number_unsigned_t>();
     } else if (value->is_number_integer()) {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -884,6 +884,7 @@ struct ParserConfig {
  */
 struct RenderConfig {
   bool throw_at_missing_includes {true};
+  bool html_autoescape {false};
 };
 
 } // namespace inja

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2125,9 +2125,29 @@ class Renderer : public NodeVisitor {
     return !data->empty();
   }
 
+  static std::string htmlescape(const std::string& data) {
+    std::string buffer;
+    buffer.reserve(1.1 * data.size());
+    for (size_t pos = 0; pos != data.size(); ++pos) {
+      switch (data[pos]) {
+        case '&':  buffer.append("&amp;");       break;
+        case '\"': buffer.append("&quot;");      break;
+        case '\'': buffer.append("&apos;");      break;
+        case '<':  buffer.append("&lt;");        break;
+        case '>':  buffer.append("&gt;");        break;
+        default:   buffer.append(&data[pos], 1); break;
+      }
+    }
+    return buffer;
+  }
+
   void print_data(const std::shared_ptr<json> value) {
     if (value->is_string()) {
-      *output_stream << value->get_ref<const json::string_t&>();
+      if (config.html_autoescape) {
+        *output_stream << htmlescape(value->get_ref<const json::string_t&>());
+      } else {
+        *output_stream << value->get_ref<const json::string_t&>();
+      }
     } else if (value->is_number_unsigned()) {
       *output_stream << value->get<const json::number_unsigned_t>();
     } else if (value->is_number_integer()) {
@@ -2383,7 +2403,7 @@ class Renderer : public NodeVisitor {
     } break;
     case Op::Capitalize: {
       auto result = get_arguments<1>(node)[0]->get<json::string_t>();
-      result[0] = std::toupper(result[0]);
+      result[0] = static_cast<char>(::toupper(result[0]));
       std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
       make_result(std::move(result));
     } break;
@@ -2793,6 +2813,11 @@ public:
     render_config.throw_at_missing_includes = will_throw;
   }
 
+  /// Sets whether we'll automatically perform HTML escape
+  void set_html_autoescape(bool will_escape) {
+    render_config.html_autoescape = will_escape;
+  }
+
   Template parse(std::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
     return parser.parse(input, input_path);
@@ -2853,6 +2878,10 @@ public:
   std::ostream& render_to(std::ostream& os, const Template& tmpl, const json& data) {
     Renderer(render_config, template_storage, function_storage).render_to(os, tmpl, data);
     return os;
+  }
+
+  std::ostream& render_to(std::ostream& os, const std::string_view input, const json& data) {
+    return render_to(os, parse(input), data);
   }
 
   std::string load_file(const std::string& filename) {


### PR DESCRIPTION
Since (j)inja templates are often used for creating HTML, it might be useful for inja to have a feature that does this. It is pretty inconvenient to manually have to escape all JSON strings. This PR adds a one stop set_html_autoescape feature that will HTML escape all strings for you. This is only available through an Environment. 