### PR TITLE
Fix: Remove circular dependencies in headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc/latex
 examples
 
 __pycache__
+/CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ execute_process(COMMAND scripts/update_single_include.sh WORKING_DIRECTORY ${PRO
 if(BUILD_TESTING AND INJA_BUILD_TESTS)
   enable_testing()
 
+  add_definitions(-D__TEST_DIR__=${CMAKE_CURRENT_SOURCE_DIR}/test)
+
   add_executable(inja_test test/test.cpp)
   target_link_libraries(inja_test PRIVATE inja)
   target_include_directories(inja_test PRIVATE include third_party/include)
@@ -104,7 +106,8 @@ if(BUILD_TESTING AND INJA_BUILD_TESTS)
   add_test(single_inja_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/single_inja_test)
 
 
-  add_executable(inja_benchmark test/benchmark.cpp)
+  add_executable(inja_benchmark test/benchmark.cpp
+    test/test-common.hpp)
   target_link_libraries(inja_benchmark PRIVATE inja)
   target_include_directories(inja_benchmark PRIVATE third_party/include)
 endif()

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -7,12 +7,13 @@
 #include <string>
 #include <string_view>
 
+#include "json.hpp"
 #include "config.hpp"
 #include "function_storage.hpp"
-#include "inja.hpp"
 #include "parser.hpp"
 #include "renderer.hpp"
 #include "template.hpp"
+#include "throw.hpp"
 
 namespace inja {
 

--- a/include/inja/function_storage.hpp
+++ b/include/inja/function_storage.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include "inja.hpp"
+#include "json.hpp"
 
 namespace inja {
 

--- a/include/inja/inja.hpp
+++ b/include/inja/inja.hpp
@@ -25,32 +25,8 @@ SOFTWARE.
 #ifndef INCLUDE_INJA_INJA_HPP_
 #define INCLUDE_INJA_INJA_HPP_
 
-#include <nlohmann/json.hpp>
-
-namespace inja {
-#ifndef INJA_DATA_TYPE
-using json = nlohmann::json;
-#else
-using json = INJA_DATA_TYPE;
-#endif
-} // namespace inja
-
-#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(INJA_NOEXCEPTION)
-#ifndef INJA_THROW
-#define INJA_THROW(exception) throw exception
-#endif
-#else
-#include <cstdlib>
-#ifndef INJA_THROW
-#define INJA_THROW(exception)                                                                                                                                  \
-  std::abort();                                                                                                                                                \
-  std::ignore = exception
-#endif
-#ifndef INJA_NOEXCEPTION
-#define INJA_NOEXCEPTION
-#endif
-#endif
-
+#include "json.hpp"
+#include "throw.hpp"
 #include "environment.hpp"
 #include "exceptions.hpp"
 #include "parser.hpp"

--- a/include/inja/json.hpp
+++ b/include/inja/json.hpp
@@ -1,0 +1,14 @@
+#ifndef INCLUDE_INJA_JSON_HPP_
+#define INCLUDE_INJA_JSON_HPP_
+
+#include <nlohmann/json.hpp>
+
+namespace inja {
+#ifndef INJA_DATA_TYPE
+using json = nlohmann::json;
+#else
+using json = INJA_DATA_TYPE;
+#endif
+} // namespace inja
+
+#endif // INCLUDE_INJA_JSON_HPP_

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include "function_storage.hpp"
-#include "inja.hpp"
 #include "utils.hpp"
+#include "json.hpp"
 
 namespace inja {
 

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -14,10 +14,10 @@
 #include "config.hpp"
 #include "exceptions.hpp"
 #include "function_storage.hpp"
-#include "inja.hpp"
 #include "lexer.hpp"
 #include "node.hpp"
 #include "template.hpp"
+#include "throw.hpp"
 #include "token.hpp"
 
 namespace inja {

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -18,9 +18,9 @@
 #include "config.hpp"
 #include "exceptions.hpp"
 #include "function_storage.hpp"
-#include "inja.hpp"
 #include "node.hpp"
 #include "template.hpp"
+#include "throw.hpp"
 #include "utils.hpp"
 
 namespace inja {

--- a/include/inja/throw.hpp
+++ b/include/inja/throw.hpp
@@ -1,0 +1,20 @@
+#ifndef INCLUDE_INJA_THROW_HPP_
+#define INCLUDE_INJA_THROW_HPP_
+
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(INJA_NOEXCEPTION)
+#ifndef INJA_THROW
+#define INJA_THROW(exception) throw exception
+#endif
+#else
+#include <cstdlib>
+#ifndef INJA_THROW
+#define INJA_THROW(exception) \
+std::abort();                 \
+    std::ignore = exception
+#endif
+#ifndef INJA_NOEXCEPTION
+#define INJA_NOEXCEPTION
+#endif
+#endif
+
+#endif // INCLUDE_INJA_THROW_HPP_

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -25,6 +25,10 @@ SOFTWARE.
 #ifndef INCLUDE_INJA_INJA_HPP_
 #define INCLUDE_INJA_INJA_HPP_
 
+// #include "json.hpp"
+#ifndef INCLUDE_INJA_JSON_HPP_
+#define INCLUDE_INJA_JSON_HPP_
+
 #include <nlohmann/json.hpp>
 
 namespace inja {
@@ -35,6 +39,12 @@ using json = INJA_DATA_TYPE;
 #endif
 } // namespace inja
 
+#endif // INCLUDE_INJA_JSON_HPP_
+
+// #include "throw.hpp"
+#ifndef INCLUDE_INJA_THROW_HPP_
+#define INCLUDE_INJA_THROW_HPP_
+
 #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(INJA_NOEXCEPTION)
 #ifndef INJA_THROW
 #define INJA_THROW(exception) throw exception
@@ -42,14 +52,16 @@ using json = INJA_DATA_TYPE;
 #else
 #include <cstdlib>
 #ifndef INJA_THROW
-#define INJA_THROW(exception)                                                                                                                                  \
-  std::abort();                                                                                                                                                \
-  std::ignore = exception
+#define INJA_THROW(exception) \
+std::abort();                 \
+    std::ignore = exception
 #endif
 #ifndef INJA_NOEXCEPTION
 #define INJA_NOEXCEPTION
 #endif
 #endif
+
+#endif // INCLUDE_INJA_THROW_HPP_
 
 // #include "environment.hpp"
 #ifndef INCLUDE_INJA_ENVIRONMENT_HPP_
@@ -60,6 +72,8 @@ using json = INJA_DATA_TYPE;
 #include <sstream>
 #include <string>
 #include <string_view>
+
+// #include "json.hpp"
 
 // #include "config.hpp"
 #ifndef INCLUDE_INJA_CONFIG_HPP_
@@ -98,7 +112,7 @@ using json = INJA_DATA_TYPE;
 #include <utility>
 #include <vector>
 
-// #include "inja.hpp"
+// #include "json.hpp"
 
 
 namespace inja {
@@ -235,8 +249,6 @@ public:
 
 #endif // INCLUDE_INJA_FUNCTION_STORAGE_HPP_
 
-// #include "inja.hpp"
-
 // #include "utils.hpp"
 #ifndef INCLUDE_INJA_UTILS_HPP_
 #define INCLUDE_INJA_UTILS_HPP_
@@ -357,6 +369,8 @@ inline void replace_substring(std::string& s, const std::string& f, const std::s
 } // namespace inja
 
 #endif // INCLUDE_INJA_UTILS_HPP_
+
+// #include "json.hpp"
 
 
 namespace inja {
@@ -904,8 +918,6 @@ struct RenderConfig {
 
 // #include "function_storage.hpp"
 
-// #include "inja.hpp"
-
 // #include "parser.hpp"
 #ifndef INCLUDE_INJA_PARSER_HPP_
 #define INCLUDE_INJA_PARSER_HPP_
@@ -925,8 +937,6 @@ struct RenderConfig {
 // #include "exceptions.hpp"
 
 // #include "function_storage.hpp"
-
-// #include "inja.hpp"
 
 // #include "lexer.hpp"
 #ifndef INCLUDE_INJA_LEXER_HPP_
@@ -1447,6 +1457,8 @@ public:
 // #include "node.hpp"
 
 // #include "template.hpp"
+
+// #include "throw.hpp"
 
 // #include "token.hpp"
 
@@ -2108,11 +2120,11 @@ public:
 
 // #include "function_storage.hpp"
 
-// #include "inja.hpp"
-
 // #include "node.hpp"
 
 // #include "template.hpp"
+
+// #include "throw.hpp"
 
 // #include "utils.hpp"
 
@@ -2763,6 +2775,8 @@ public:
 #endif // INCLUDE_INJA_RENDERER_HPP_
 
 // #include "template.hpp"
+
+// #include "throw.hpp"
 
 
 namespace inja {

--- a/test/test-common.hpp
+++ b/test/test-common.hpp
@@ -1,0 +1,9 @@
+#ifndef INCLUDE_TEST_COMMON_HPP_
+#define INCLUDE_TEST_COMMON_HPP_
+
+#include <string>
+#include <doctest/doctest.h>
+
+extern const std::string test_file_directory;
+
+#endif // INCLUDE_TEST_COMMON_HPP_

--- a/test/test-files.cpp
+++ b/test/test-files.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
-#include <doctest/doctest.h>
-
 #include "inja/environment.hpp"
-#include "inja/inja.hpp"
+
+#include "test-common.hpp"
 
 TEST_CASE("loading") {
   inja::Environment env;
@@ -99,7 +98,8 @@ TEST_CASE("include-in-memory-and-file-template") {
   inja::json data;
   data["name"] = "Jeff";
 
-  CHECK_THROWS_WITH(env.render_file("include-both.txt", data), "[inja.exception.file_error] failed accessing file at '../test/data/body'");
+  std::string error_message = "[inja.exception.file_error] failed accessing file at '" + test_file_directory + "body'";
+  CHECK_THROWS_WITH(env.render_file("include-both.txt", data), error_message.c_str());
 
   const auto parsed_body_template = env.parse("Bye {{ name }}.");
   env.include_template("body", parsed_body_template);

--- a/test/test-functions.cpp
+++ b/test/test-functions.cpp
@@ -1,10 +1,8 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
-#include <doctest/doctest.h>
-#include <string>
-
 #include "inja/environment.hpp"
-#include "inja/inja.hpp"
+
+#include "test-common.hpp"
 
 TEST_CASE("functions") {
   inja::Environment env;

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -1,11 +1,8 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
-#include <doctest/doctest.h>
-#include <string>
-
 #include "inja/environment.hpp"
-#include "inja/inja.hpp"
-#include "inja/template.hpp"
+
+#include "test-common.hpp"
 
 TEST_CASE("types") {
   inja::Environment env;

--- a/test/test-units.cpp
+++ b/test/test-units.cpp
@@ -1,12 +1,8 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
-#include <doctest/doctest.h>
-#include <string>
-
 #include "inja/environment.hpp"
-#include "inja/function_storage.hpp"
-#include "inja/inja.hpp"
-#include "inja/utils.hpp"
+
+#include "test-common.hpp"
 
 TEST_CASE("source location") {
   std::string content = R""""(Lorem Ipsum

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,16 +1,15 @@
 // Copyright (c) 2020 Pantor. All rights reserved.
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
-#include <doctest/doctest.h>
-
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #define JSON_NO_IO 1
-#include "inja/inja.hpp"
-
-const std::string test_file_directory {"../test/data/"};
 
 #include "test-files.cpp"
 #include "test-functions.cpp"
 #include "test-renderer.cpp"
 #include "test-units.cpp"
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+const std::string test_file_directory { xstr(__TEST_DIR__)"/data/" };


### PR DESCRIPTION
This fix removes circular dependencies from specific headers `node.hpp` and `function_storage.hpp` to grouping header `inja.hpp`. This problem leads to high CPU load when parsing sources by `clangd` language server. Also, many errors are highlighted in the sources.