### PR TITLE
Make `htmlescape` function public

### DIFF
--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -26,6 +26,25 @@
 namespace inja {
 
 /*!
+@brief Escapes HTML
+*/
+inline std::string htmlescape(const std::string& data) {
+  std::string buffer;
+  buffer.reserve(1.1 * data.size());
+  for (size_t pos = 0; pos != data.size(); ++pos) {
+    switch (data[pos]) {
+      case '&':  buffer.append("&amp;");       break;
+      case '\"': buffer.append("&quot;");      break;
+      case '\'': buffer.append("&apos;");      break;
+      case '<':  buffer.append("&lt;");        break;
+      case '>':  buffer.append("&gt;");        break;
+      default:   buffer.append(&data[pos], 1); break;
+    }
+  }
+  return buffer;
+}
+
+/*!
  * \brief Class for rendering a Template with data.
  */
 class Renderer : public NodeVisitor {
@@ -61,22 +80,6 @@ class Renderer : public NodeVisitor {
       return false;
     }
     return !data->empty();
-  }
-
-  static std::string htmlescape(const std::string& data) {
-    std::string buffer;
-    buffer.reserve(1.1 * data.size());
-    for (size_t pos = 0; pos != data.size(); ++pos) {
-      switch (data[pos]) {
-        case '&':  buffer.append("&amp;");       break;
-        case '\"': buffer.append("&quot;");      break;
-        case '\'': buffer.append("&apos;");      break;
-        case '<':  buffer.append("&lt;");        break;
-        case '>':  buffer.append("&gt;");        break;
-        default:   buffer.append(&data[pos], 1); break;
-      }
-    }
-    return buffer;
   }
 
   void print_data(const std::shared_ptr<json>& value) {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2120,6 +2120,25 @@ public:
 namespace inja {
 
 /*!
+@brief Escapes HTML
+*/
+inline std::string htmlescape(const std::string& data) {
+  std::string buffer;
+  buffer.reserve(1.1 * data.size());
+  for (size_t pos = 0; pos != data.size(); ++pos) {
+    switch (data[pos]) {
+      case '&':  buffer.append("&amp;");       break;
+      case '\"': buffer.append("&quot;");      break;
+      case '\'': buffer.append("&apos;");      break;
+      case '<':  buffer.append("&lt;");        break;
+      case '>':  buffer.append("&gt;");        break;
+      default:   buffer.append(&data[pos], 1); break;
+    }
+  }
+  return buffer;
+}
+
+/*!
  * \brief Class for rendering a Template with data.
  */
 class Renderer : public NodeVisitor {
@@ -2155,22 +2174,6 @@ class Renderer : public NodeVisitor {
       return false;
     }
     return !data->empty();
-  }
-
-  static std::string htmlescape(const std::string& data) {
-    std::string buffer;
-    buffer.reserve(1.1 * data.size());
-    for (size_t pos = 0; pos != data.size(); ++pos) {
-      switch (data[pos]) {
-        case '&':  buffer.append("&amp;");       break;
-        case '\"': buffer.append("&quot;");      break;
-        case '\'': buffer.append("&apos;");      break;
-        case '<':  buffer.append("&lt;");        break;
-        case '>':  buffer.append("&gt;");        break;
-        default:   buffer.append(&data[pos], 1); break;
-      }
-    }
-    return buffer;
   }
 
   void print_data(const std::shared_ptr<json>& value) {


### PR DESCRIPTION
Hi, thanks for this library, and adding HTML escaping in #292!

It'd be convenient if the `htmlescape` function was public for templates where HTML escaping is needed for some variables but not others.

```cpp
std::string escaped = inja::htmlescape("<h1></h1>");
```

Edit: Another idea would be to have a way to disable escaping for certain variables in templates (this would be a safer approach since it wouldn't require disabling autoescape).