### PR TITLE
Prevent local stack memory leakage when parsing

### DIFF
--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -573,6 +573,7 @@ class Parser {
           throw_parser_error("unmatched for");
         }
       }
+        current_block = nullptr;
         return;
       case Token::Kind::Text: {
         current_block->nodes.emplace_back(std::make_shared<TextNode>(tok.text.data() - tmpl.content.c_str(), tok.text.size()));
@@ -617,6 +618,7 @@ class Parser {
       } break;
       }
     }
+    current_block = nullptr;
   }
 
 public:

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2016,6 +2016,7 @@ class Parser {
           throw_parser_error("unmatched for");
         }
       }
+        current_block = nullptr;
         return;
       case Token::Kind::Text: {
         current_block->nodes.emplace_back(std::make_shared<TextNode>(tok.text.data() - tmpl.content.c_str(), tok.text.size()));
@@ -2060,6 +2061,7 @@ class Parser {
       } break;
       }
     }
+    current_block = nullptr;
   }
 
 public:


### PR DESCRIPTION
We need to resets current_block to a nullptr after parsing the template in `parse_into`, otherwise, current_block will refer to local stack space after we return from Parser::parse.