### PR TITLE
Initialize missing fields in Lexer constructor

### DIFF
--- a/include/inja/lexer.hpp
+++ b/include/inja/lexer.hpp
@@ -273,7 +273,7 @@ class Lexer {
   }
 
 public:
-  explicit Lexer(const LexerConfig& config): config(config), state(State::Text), minus_state(MinusState::Number) {}
+  explicit Lexer(const LexerConfig& config): config(config), state(State::Text), minus_state(MinusState::Number), tok_start(0), pos(0) {}
 
   SourceLocation current_position() const {
     return get_source_location(m_in, tok_start);

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1294,7 +1294,7 @@ class Lexer {
   }
 
 public:
-  explicit Lexer(const LexerConfig& config): config(config), state(State::Text), minus_state(MinusState::Number) {}
+  explicit Lexer(const LexerConfig& config): config(config), state(State::Text), minus_state(MinusState::Number), tok_start(0), pos(0) {}
 
   SourceLocation current_position() const {
     return get_source_location(m_in, tok_start);

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -7,10 +7,10 @@ inja::Environment env;
 
 const std::filesystem::path test_file_directory {"../test/data/benchmark/"};
 
-const auto small_data = env.load_json(test_file_directory / "small_data.json");
-const auto large_data = env.load_json(test_file_directory / "large_data.json");
-const std::string medium_template = env.load_file(test_file_directory / "medium_template.txt");
-const std::string large_template = env.load_file(test_file_directory / "large_template.txt");
+const auto small_data = env.load_json((test_file_directory / "small_data.json").string());
+const auto large_data = env.load_json((test_file_directory / "large_data.json").string());
+const std::string medium_template = env.load_file((test_file_directory / "medium_template.txt").string());
+const std::string large_template = env.load_file((test_file_directory / "large_template.txt").string());
 
 BENCHMARK(SmallDataMediumTemplate, render, 5, 30) {
   env.render(medium_template, small_data);

--- a/test/test-files.cpp
+++ b/test/test-files.cpp
@@ -98,7 +98,7 @@ TEST_CASE("include-in-memory-and-file-template") {
   inja::json data;
   data["name"] = "Jeff";
 
-  std::string error_message = "[inja.exception.file_error] failed accessing file at '" + test_file_directory.string() + "/body'";
+  std::string error_message = "[inja.exception.file_error] failed accessing file at '" + (test_file_directory / "body").string() + "'";
   CHECK_THROWS_WITH(env.render_file("include-both.txt", data), error_message.c_str());
 
   const auto parsed_body_template = env.parse("Bye {{ name }}.");

--- a/test/test-files.cpp
+++ b/test/test-files.cpp
@@ -10,7 +10,7 @@ TEST_CASE("loading") {
   data["name"] = "Jeff";
 
   SUBCASE("Files should be loaded") {
-    CHECK(env.load_file(test_file_directory / "simple.txt") == "Hello {{ name }}.");
+    CHECK(env.load_file((test_file_directory / "simple.txt").string()) == "Hello {{ name }}.");
   }
 
   SUBCASE("Files should be rendered") {
@@ -22,7 +22,7 @@ TEST_CASE("loading") {
   }
 
   SUBCASE("File error should throw") {
-    std::string path(test_file_directory / "does-not-exist");
+    std::string path = (test_file_directory / "does-not-exist").string();
 
     std::string file_error_message = "[inja.exception.file_error] failed accessing file at '" + path + "'";
     CHECK_THROWS_WITH(env.load_file(path), file_error_message.c_str());


### PR DESCRIPTION
- Add tok_start and pos initialization to Lexer constructor
- Fix clang-tidy uninitialized fields warning

```bash
inja/include/inja/parser.hpp:625:12: warning: 2 uninitialized fields at the end of the constructor call [clang-analyzer-optin.cplusplus.UninitializedObject]
  625 |   explicit Parser(const ParserConfig& parser_config, const LexerConfig& lexer_config, TemplateStorage& template_storage,
      |            ^
inja/include/inja/lexer.hpp:45:10: note: uninitialized field 'this->lexer.tok_start'
   45 |   size_t tok_start;
      |          ^~~~~~~~~
inja/include/inja/lexer.hpp:46:10: note: uninitialized field 'this->lexer.pos'
   46 |   size_t pos;
```