### PR TITLE
cmake: Use GNUInstallDirs for install paths and install pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,10 @@ cmake_minimum_required(VERSION 3.5)
 # is included in another CMake project.
 cmake_policy(SET CMP0077 NEW)
 
-project(inja LANGUAGES CXX VERSION 3.5.0)
+project(inja
+        DESCRIPTION "Template engine for modern C++"
+        LANGUAGES CXX
+        VERSION 3.5.0)
 
 
 option(BUILD_TESTING "Build unit tests" ON)
@@ -17,8 +20,9 @@ option(INJA_INSTALL "Generate install targets for inja" ON)
 option(INJA_INSTALL_SINGLE_HEADER "Install the single header instead" OFF)
 option(INJA_USE_EMBEDDED_JSON "Use the shipped json header if not available on the system" ON)
 
+include(GNUInstallDirs)
 
-set(INJA_INSTALL_INCLUDE_DIR "include")
+set(INJA_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 set(INJA_PACKAGE_USE_EMBEDDED_JSON OFF)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -166,7 +170,7 @@ configure_file(
 
 
 if(INJA_INSTALL)
-  set(INJA_CONFIG_PATH "lib/cmake/inja")
+  set(INJA_CONFIG_PATH "${CMAKE_INSTALL_DATADIR}/cmake/inja")
 
   # install tree package config
   configure_package_config_file(
@@ -174,6 +178,11 @@ if(INJA_INSTALL)
     ${INJA_CONFIG_PATH}/injaConfig.cmake
     INSTALL_DESTINATION ${INJA_CONFIG_PATH}
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+
+  configure_file(${PROJECT_SOURCE_DIR}/cmake/config/inja.pc.in ${CMAKE_BINARY_DIR}/inja.pc @ONLY)
+  install(FILES ${CMAKE_BINARY_DIR}/inja.pc
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig
   )
 
   if(INJA_INSTALL_SINGLE_HEADER)

--- a/cmake/config/inja.pc.in
+++ b/cmake/config/inja.pc.in
@@ -1,0 +1,5 @@
+Name: inja
+Description: @PROJECT_DESCRIPTION@
+URL: https://github.com/pantor/inja
+Version: @PROJECT_VERSION@
+Requires: nlohmann_json


### PR DESCRIPTION
This ensures that the correct include and library directories are used regardless of operating system target by leveraging the built-in GNUInstallDirs logic for determining the right directory paths.

This also fixes the path for the CMake config module files to use the right location for header-only libraries.

A pc(5) file for pkgconfig is now also created and installed.
