### PR TITLE
Add support for arbitrary expressions as elements of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ render("{{ guests.1 }}", data); // "Tom"
 
 // Objects
 render("{{ time.start }} to {{ time.end + 1 }}pm", data); // "16 to 23pm"
+
+// Array literals with arbitrary expressions as elements
+render("{{ [neighbour, \"Anna\"] }}", data); // "[\"Peter\",\"Anna\"]"
 ```
 If no variable is found, valid JSON is printed directly, otherwise an `inja::RenderError` is thrown.
 
@@ -148,6 +151,9 @@ render(R"(Guest List:
 	1: Jeff
 	2: Tom
 	3: Patrick */
+
+// Iterating over an inline array containing variables
+render("{% for guest in [neighbour, \"Anna\"] %}{{ guest }} {% endfor %}", data); // "Peter Anna "
 ```
 In a loop, the special variables `loop.index (number)`, `loop.index1 (number)`, `loop.is_first (boolean)` and `loop.is_last (boolean)` are defined. In nested loops, the parent loop variables are available e.g. via `loop.parent.index`. You can also iterate over objects like `{% for key, value in time %}`.
 

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -19,6 +19,7 @@ class BlockNode;
 class TextNode;
 class ExpressionNode;
 class LiteralNode;
+class ArrayNode;
 class DataNode;
 class FunctionNode;
 class ExpressionListNode;
@@ -40,6 +41,7 @@ public:
   virtual void visit(const TextNode& node) = 0;
   virtual void visit(const ExpressionNode& node) = 0;
   virtual void visit(const LiteralNode& node) = 0;
+  virtual void visit(const ArrayNode& node) = 0;
   virtual void visit(const DataNode& node) = 0;
   virtual void visit(const FunctionNode& node) = 0;
   virtual void visit(const ExpressionListNode& node) = 0;
@@ -103,6 +105,18 @@ public:
   const json value;
 
   explicit LiteralNode(std::string_view data_text, size_t pos): ExpressionNode(pos), value(json::parse(data_text)) {}
+
+  void accept(NodeVisitor& v) const override {
+    v.visit(*this);
+  }
+};
+
+class ArrayNode : public ExpressionNode {
+public:
+  // cppcheck-suppress unusedStructMember
+  std::vector<std::shared_ptr<ExpressionNode>> elements;
+
+  explicit ArrayNode(size_t pos): ExpressionNode(pos) {}
 
   void accept(NodeVisitor& v) const override {
     v.visit(*this);

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -167,9 +167,28 @@ class Parser {
       } break;
       case Token::Kind::LeftBracket: {
         if (current_brace_level == 0 && current_bracket_level == 0) {
-          literal_start = tok.text;
+          auto array_node = std::make_shared<ArrayNode>(tok.text.data() - tmpl.content.c_str());
+          get_next_token();
+          if (tok.kind != Token::Kind::RightBracket) {
+            while (true) {
+              auto expr = parse_expression(tmpl);
+              if (!expr) {
+                break;
+              }
+              array_node->elements.emplace_back(expr);
+              if (tok.kind != Token::Kind::Comma) {
+                break;
+              }
+              get_next_token();
+            }
+          }
+          if (tok.kind != Token::Kind::RightBracket) {
+            throw_parser_error("expected ']', got '" + tok.describe() + "'");
+          }
+          arguments.emplace_back(array_node);
+        } else {
+          current_bracket_level += 1;
         }
-        current_bracket_level += 1;
       } break;
       case Token::Kind::LeftBrace: {
         if (current_brace_level == 0 && current_bracket_level == 0) {
@@ -179,7 +198,7 @@ class Parser {
       } break;
       case Token::Kind::RightBracket: {
         if (current_bracket_level == 0) {
-          throw_parser_error("unexpected ']'");
+          goto break_loop;
         }
 
         current_bracket_level -= 1;

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -128,7 +128,7 @@ class Renderer : public NodeVisitor {
     return std::make_shared<json>(*result);
   }
 
-  void throw_renderer_error(const std::string& message, const AstNode& node) {
+  [[noreturn]] void throw_renderer_error(const std::string& message, const AstNode& node) {
     const SourceLocation loc = get_source_location(current_template->content, node.pos);
     INJA_THROW(RenderError(message, loc));
   }
@@ -214,6 +214,30 @@ class Renderer : public NodeVisitor {
 
   void visit(const LiteralNode& node) override {
     data_eval_stack.push(&node.value);
+  }
+
+  void visit(const ArrayNode& node) override {
+    const size_t N = node.elements.size();
+    for (const auto& e : node.elements) {
+      e->accept(*this);
+    }
+    if (data_eval_stack.size() < N) {
+      throw_renderer_error("malformed array literal", node);
+    }
+    json result = json::array();
+    result.get_ref<json::array_t&>().resize(N);
+    for (size_t i = 0; i < N; ++i) {
+      const auto v = data_eval_stack.top();
+      data_eval_stack.pop();
+      if (!v) {
+        const auto data_node = not_found_stack.top();
+        not_found_stack.pop();
+        throw_renderer_error("variable '" + static_cast<std::string>(data_node->name) + "' not found", *data_node);
+      } else {
+        result[N - i - 1] = *v;
+      }
+    }
+    make_result(std::move(result));
   }
 
   void visit(const DataNode& node) override {

--- a/include/inja/statistics.hpp
+++ b/include/inja/statistics.hpp
@@ -19,6 +19,12 @@ class StatisticsVisitor : public NodeVisitor {
   void visit(const ExpressionNode&) override {}
   void visit(const LiteralNode&) override {}
 
+  void visit(const ArrayNode& node) override {
+    for (const auto& e : node.elements) {
+      e->accept(*this);
+    }
+  }
+
   void visit(const DataNode&) override {
     variable_counter += 1;
   }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -384,6 +384,7 @@ class BlockNode;
 class TextNode;
 class ExpressionNode;
 class LiteralNode;
+class ArrayNode;
 class DataNode;
 class FunctionNode;
 class ExpressionListNode;
@@ -405,6 +406,7 @@ public:
   virtual void visit(const TextNode& node) = 0;
   virtual void visit(const ExpressionNode& node) = 0;
   virtual void visit(const LiteralNode& node) = 0;
+  virtual void visit(const ArrayNode& node) = 0;
   virtual void visit(const DataNode& node) = 0;
   virtual void visit(const FunctionNode& node) = 0;
   virtual void visit(const ExpressionListNode& node) = 0;
@@ -468,6 +470,18 @@ public:
   const json value;
 
   explicit LiteralNode(std::string_view data_text, size_t pos): ExpressionNode(pos), value(json::parse(data_text)) {}
+
+  void accept(NodeVisitor& v) const override {
+    v.visit(*this);
+  }
+};
+
+class ArrayNode : public ExpressionNode {
+public:
+  // cppcheck-suppress unusedStructMember
+  std::vector<std::shared_ptr<ExpressionNode>> elements;
+
+  explicit ArrayNode(size_t pos): ExpressionNode(pos) {}
 
   void accept(NodeVisitor& v) const override {
     v.visit(*this);
@@ -762,6 +776,12 @@ class StatisticsVisitor : public NodeVisitor {
   void visit(const TextNode&) override {}
   void visit(const ExpressionNode&) override {}
   void visit(const LiteralNode&) override {}
+
+  void visit(const ArrayNode& node) override {
+    for (const auto& e : node.elements) {
+      e->accept(*this);
+    }
+  }
 
   void visit(const DataNode&) override {
     variable_counter += 1;
@@ -1617,9 +1637,28 @@ class Parser {
       } break;
       case Token::Kind::LeftBracket: {
         if (current_brace_level == 0 && current_bracket_level == 0) {
-          literal_start = tok.text;
+          auto array_node = std::make_shared<ArrayNode>(tok.text.data() - tmpl.content.c_str());
+          get_next_token();
+          if (tok.kind != Token::Kind::RightBracket) {
+            while (true) {
+              auto expr = parse_expression(tmpl);
+              if (!expr) {
+                break;
+              }
+              array_node->elements.emplace_back(expr);
+              if (tok.kind != Token::Kind::Comma) {
+                break;
+              }
+              get_next_token();
+            }
+          }
+          if (tok.kind != Token::Kind::RightBracket) {
+            throw_parser_error("expected ']', got '" + tok.describe() + "'");
+          }
+          arguments.emplace_back(array_node);
+        } else {
+          current_bracket_level += 1;
         }
-        current_bracket_level += 1;
       } break;
       case Token::Kind::LeftBrace: {
         if (current_brace_level == 0 && current_bracket_level == 0) {
@@ -1629,7 +1668,7 @@ class Parser {
       } break;
       case Token::Kind::RightBracket: {
         if (current_bracket_level == 0) {
-          throw_parser_error("unexpected ']'");
+          goto break_loop;
         }
 
         current_bracket_level -= 1;
@@ -2280,7 +2319,7 @@ class Renderer : public NodeVisitor {
     return std::make_shared<json>(*result);
   }
 
-  void throw_renderer_error(const std::string& message, const AstNode& node) {
+  [[noreturn]] void throw_renderer_error(const std::string& message, const AstNode& node) {
     const SourceLocation loc = get_source_location(current_template->content, node.pos);
     INJA_THROW(RenderError(message, loc));
   }
@@ -2366,6 +2405,30 @@ class Renderer : public NodeVisitor {
 
   void visit(const LiteralNode& node) override {
     data_eval_stack.push(&node.value);
+  }
+
+  void visit(const ArrayNode& node) override {
+    const size_t N = node.elements.size();
+    for (const auto& e : node.elements) {
+      e->accept(*this);
+    }
+    if (data_eval_stack.size() < N) {
+      throw_renderer_error("malformed array literal", node);
+    }
+    json result = json::array();
+    result.get_ref<json::array_t&>().resize(N);
+    for (size_t i = 0; i < N; ++i) {
+      const auto v = data_eval_stack.top();
+      data_eval_stack.pop();
+      if (!v) {
+        const auto data_node = not_found_stack.top();
+        not_found_stack.pop();
+        throw_renderer_error("variable '" + static_cast<std::string>(data_node->name) + "' not found", *data_node);
+      } else {
+        result[N - i - 1] = *v;
+      }
+    }
+    make_result(std::move(result));
   }
 
   void visit(const DataNode& node) override {

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -160,6 +160,18 @@ Yeah!
     CHECK(env.render("{{ brother.name | upper | lower }}", data) == "chris");
     CHECK(env.render("{{ [\"C\", \"A\", \"B\"] | sort | join(\",\") }}", data) == "A,B,C");
   }
+
+  SUBCASE("array expressions") {
+    CHECK(env.render("{% set v=10 %}{% set l=[v] %}{{ l }}", data) == "[10]");
+    CHECK(env.render("{% set v=10 %}{{ [v, 20, \"x\"] }}", data) == "[10,20,\"x\"]");
+    CHECK(env.render("{{ [1, 2, 3] }}", data) == "[1,2,3]");
+    CHECK(env.render("{{ [[1,2],[3,4]] }}", data) == "[[1,2],[3,4]]");
+    CHECK(env.render("{{ [] }}", data) == "[]");
+    CHECK(env.render("{% set v=2 %}{% for i in [1, v, 3] %}{{ i }};{% endfor %}", data) == "1;2;3;");
+    CHECK(env.render("{{ at([10, 20, 30], 1) }}", data) == "20");
+    CHECK_THROWS_WITH(env.render("{{ [undefined_var] }}", data),
+                      "[inja.exception.render_error] (at 1:5) variable 'undefined_var' not found");
+  }
 }
 
 TEST_CASE("templates") {


### PR DESCRIPTION
This MR adds support for parsing and executing expressions in arrays. 

These examples show how the improvements work:

```c++
// Array literals with arbitrary expressions as elements
render("{% set neighbour=\"Peter\" %} {{ [neighbour, \"Anna\"] }}", data); // "[\"Peter\",\"Anna\"]"
```

```c++
// Iterating over an inline array containing variables
render("{% for guest in [neighbour, \"Anna\"] %}{{ guest }} {% endfor %}", data); // "Peter Anna "
```