### PR TITLE
Add Jinja2-style macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,17 @@ env.render(R"({% include "macros.tpl" %}{{ greet("Bob") }})", data); // "Hi Bob"
 
 If a macro is called without a value for a parameter that has no default, an `inja::RenderError` is thrown. Defining two macros with the same name in one template, or leaving a `{% macro %}` without a matching `{% endmacro %}`, raises an `inja::ParserError`.
 
+Macro calls nested more than `RenderConfig::max_macro_recursion_depth` deep (200 by default,
+configurable via `Environment::set_max_macro_recursion_depth`) throw an `inja::RenderError` naming
+the offending macro, instead of exhausting the C++ call stack - this guards against a runaway
+recursive macro that never hits its base case:
+
+```.cpp
+// No base case - throws instead of crashing the process.
+env.render(R"({% macro loop(n) %}{{ n }},{{ loop(n + 1) }}{% endmacro %}{{ loop(1) }})", data);
+// throws inja::RenderError: macro recursion depth exceeded 200 while calling macro 'loop'
+```
+
 ### Template Inheritance
 
 Template inheritance allows you to build a base *skeleton* template that contains all the common elements and defines blocks that child templates can override. Lets show an example: The base template

--- a/README.md
+++ b/README.md
@@ -323,6 +323,54 @@ env.add_void_callback("log", 1, [greet](Arguments args) {
 env.render("{{ log(neighbour) }}", data); // Prints nothing to result, only to cout...
 ```
 
+### Macros
+
+Macros let you define a reusable chunk of template that takes parameters and is called like a function. They are similar in spirit to Jinja2 macros. A macro is defined with `{% macro name(params) %}...{% endmacro %}` and called with `{{ name(args) }}`.
+
+```.cpp
+// Define a macro and use it
+env.render(R"({% macro greet(name) %}Hello {{ name }}!{% endmacro %}{{ greet("world") }})", data);
+// "Hello world!"
+```
+
+Parameters may have default values, which are used when the call omits the corresponding positional argument:
+```.cpp
+env.render(R"(
+{% macro link(href, label="click me") %}<a href="{{ href }}">{{ label }}</a>{% endmacro -%}
+{{ link("/home") }}
+{{ link("/about", "About") }}
+)", data);
+// <a href="/home">click me</a>
+// <a href="/about">About</a>
+```
+
+Macros have an isolated local scope: they see only their own parameters and the global input data, *not* `set` variables, loop variables, or other local state of the calling template. Parameters never leak back to the caller.
+
+```.cpp
+// Outer set variable is NOT visible inside the macro.
+env.render(R"({% set city = "Brno" %}{% macro m() %}{{ city }}{% endmacro %}{{ m() }})", data);
+// throws inja::RenderError: variable 'city' not found
+```
+
+Macros may call other macros and may also call themselves recursively:
+```.cpp
+env.render(R"(
+{%- macro down(n) -%}
+  {%- if n > 0 -%}{{ n }},{{ down(n - 1) }}{%- endif -%}
+{%- endmacro -%}
+{{ down(3) }}
+)", data); // "3,2,1,"
+```
+
+Macros defined in an included template are automatically *hoisted* into the including template's namespace, so they can be called after the `{% include %}` statement:
+```.cpp
+// macros.tpl: {% macro greet(n) %}Hi {{ n }}{% endmacro %}
+env.include_template("macros.tpl", env.parse("{% macro greet(n) %}Hi {{ n }}{% endmacro %}"));
+env.render(R"({% include "macros.tpl" %}{{ greet("Bob") }})", data); // "Hi Bob"
+```
+
+If a macro is called without a value for a parameter that has no default, an `inja::RenderError` is thrown. Defining two macros with the same name in one template, or leaving a `{% macro %}` without a matching `{% endmacro %}`, raises an `inja::ParserError`.
+
 ### Template Inheritance
 
 Template inheritance allows you to build a base *skeleton* template that contains all the common elements and defines blocks that child templates can override. Lets show an example: The base template

--- a/include/inja/config.hpp
+++ b/include/inja/config.hpp
@@ -76,6 +76,10 @@ struct ParserConfig {
 struct RenderConfig {
   bool throw_at_missing_includes {true};
   bool html_autoescape {false};
+  // Maximum nesting depth of macro calls (a macro calling itself, mutually recursive macros, or
+  // a macro invoked as a default-parameter/argument expression of another macro call all count).
+  // Exceeding it throws inja::RenderError instead of exhausting the C++ call stack.
+  size_t max_macro_recursion_depth {200};
 };
 
 } // namespace inja

--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -97,6 +97,11 @@ public:
     render_config.html_autoescape = will_escape;
   }
 
+  /// Sets the maximum nesting depth of macro calls before an inja::RenderError is thrown
+  void set_max_macro_recursion_depth(size_t max_depth) {
+    render_config.max_macro_recursion_depth = max_depth;
+  }
+
   Template parse(std::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
     return parser.parse(input, input_path);

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -14,6 +14,8 @@
 
 namespace inja {
 
+struct Template;
+
 class NodeVisitor;
 class BlockNode;
 class TextNode;
@@ -31,6 +33,8 @@ class IncludeStatementNode;
 class ExtendsStatementNode;
 class BlockStatementNode;
 class SetStatementNode;
+class MacroStatementNode;
+class MacroCallNode;
 
 class NodeVisitor {
 public:
@@ -52,6 +56,8 @@ public:
   virtual void visit(const ExtendsStatementNode& node) = 0;
   virtual void visit(const BlockStatementNode& node) = 0;
   virtual void visit(const SetStatementNode& node) = 0;
+  virtual void visit(const MacroStatementNode& node) = 0;
+  virtual void visit(const MacroCallNode& node) = 0;
 };
 
 /*!
@@ -365,6 +371,46 @@ public:
   ExpressionListNode expression;
 
   explicit SetStatementNode(const std::string& key, size_t pos): StatementNode(pos), key(key) {}
+
+  void accept(NodeVisitor& v) const override {
+    v.visit(*this);
+  }
+};
+
+struct MacroParameter {
+  // cppcheck-suppress unusedStructMember
+  std::string name;
+  std::shared_ptr<ExpressionNode> default_value;
+};
+
+class MacroStatementNode : public StatementNode {
+public:
+  const std::string name;
+  // cppcheck-suppress unusedStructMember
+  std::vector<MacroParameter> parameters;
+  // cppcheck-suppress unusedStructMember
+  BlockNode body;
+  BlockNode* const parent;
+  // Holds the source content the macro body references via TextNode offsets.
+  // Stored as shared_ptr so it stays alive even when the originally parsed
+  // Template is copied or destroyed (e.g. when added via include_template).
+  std::shared_ptr<Template> owner_template;
+
+  explicit MacroStatementNode(BlockNode* const parent, const std::string& name, size_t pos): StatementNode(pos), name(name), parent(parent) {}
+
+  void accept(NodeVisitor& v) const override {
+    v.visit(*this);
+  }
+};
+
+class MacroCallNode : public ExpressionNode {
+public:
+  const std::string name;
+  std::vector<std::shared_ptr<ExpressionNode>> arguments;
+  std::shared_ptr<MacroStatementNode> macro;
+
+  explicit MacroCallNode(const std::string& name, std::shared_ptr<MacroStatementNode> macro, size_t pos)
+      : ExpressionNode(pos), name(name), macro(std::move(macro)) {}
 
   void accept(NodeVisitor& v) const override {
     v.visit(*this);

--- a/include/inja/node.hpp
+++ b/include/inja/node.hpp
@@ -407,10 +407,14 @@ class MacroCallNode : public ExpressionNode {
 public:
   const std::string name;
   std::vector<std::shared_ptr<ExpressionNode>> arguments;
-  std::shared_ptr<MacroStatementNode> macro;
+  // Weak: the macro's owning Template (its macro_storage / root BlockNode) already keeps the
+  // MacroStatementNode alive for as long as it can be called. A shared_ptr here would create a
+  // reference cycle for a (self- or mutually-) recursive macro, since its own body contains this
+  // MacroCallNode, which would then keep the MacroStatementNode that owns that body alive forever.
+  std::weak_ptr<MacroStatementNode> macro;
 
-  explicit MacroCallNode(const std::string& name, std::shared_ptr<MacroStatementNode> macro, size_t pos)
-      : ExpressionNode(pos), name(name), macro(std::move(macro)) {}
+  explicit MacroCallNode(const std::string& name, const std::shared_ptr<MacroStatementNode>& macro, size_t pos)
+      : ExpressionNode(pos), name(name), macro(macro) {}
 
   void accept(NodeVisitor& v) const override {
     v.visit(*this);

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -48,6 +48,11 @@ class Parser {
   // Created lazily on the first macro definition in the current parse.
   std::shared_ptr<Template> current_macro_owner;
 
+  // Points to the most recently created TextNode, used to detect (without RTTI)
+  // whether a block ends with literal text so a trailing newline can be trimmed
+  // from a macro body.
+  const AstNode* last_text_node {nullptr};
+
   std::stack<IfStatementNode*> if_statement_stack;
   std::stack<ForStatementNode*> for_statement_stack;
   std::stack<BlockStatementNode*> block_statement_stack;
@@ -691,6 +696,30 @@ class Parser {
       auto& macro_statement_data = macro_statement_stack.top();
       get_next_token();
 
+      // Trim a single trailing newline from the macro body so a definition such as
+      //   ## macro foo()
+      //   test
+      //   ## endmacro
+      // expands to "test" rather than "test\n" when called. The newline before
+      // 'endmacro' belongs to the source layout, not to the macro's value.
+      auto& body_nodes = macro_statement_data->body.nodes;
+      if (!body_nodes.empty() && body_nodes.back().get() == last_text_node) {
+        auto* const text_node = static_cast<TextNode*>(body_nodes.back().get());
+        const char* const data = tmpl.content.c_str() + text_node->pos;
+        size_t new_length = text_node->length;
+        if (new_length > 0 && data[new_length - 1] == '\n') {
+          new_length -= 1;
+          if (new_length > 0 && data[new_length - 1] == '\r') {
+            new_length -= 1;
+          }
+          if (new_length == 0) {
+            body_nodes.pop_back();
+          } else {
+            body_nodes.back() = std::make_shared<TextNode>(text_node->pos, new_length);
+          }
+        }
+      }
+
       current_block = macro_statement_data->parent;
       macro_statement_stack.pop();
     } else {
@@ -721,6 +750,7 @@ class Parser {
         return;
       case Token::Kind::Text: {
         current_block->nodes.emplace_back(std::make_shared<TextNode>(tok.text.data() - tmpl.content.c_str(), tok.text.size()));
+        last_text_node = current_block->nodes.back().get();
       } break;
       case Token::Kind::StatementOpen: {
         get_next_token();

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -44,9 +44,14 @@ class Parser {
   BlockNode* current_block {nullptr};
   ExpressionListNode* current_expression_list {nullptr};
 
+  // Holds a copy of the current template's content for macros to reference.
+  // Created lazily on the first macro definition in the current parse.
+  std::shared_ptr<Template> current_macro_owner;
+
   std::stack<IfStatementNode*> if_statement_stack;
   std::stack<ForStatementNode*> for_statement_stack;
   std::stack<BlockStatementNode*> block_statement_stack;
+  std::stack<MacroStatementNode*> macro_statement_stack;
 
   void throw_parser_error(const std::string& message) const {
     INJA_THROW(ParserError(message, lexer.current_position()));
@@ -214,7 +219,9 @@ class Parser {
 
           // Functions
         } else if (peek_tok.kind == Token::Kind::LeftParen) {
-          auto func = std::make_shared<FunctionNode>(tok.text, tok.text.data() - tmpl.content.c_str());
+          const std::string call_name = static_cast<std::string>(tok.text);
+          const size_t call_pos = tok.text.data() - tmpl.content.c_str();
+          auto func = std::make_shared<FunctionNode>(tok.text, call_pos);
           get_next_token();
           do {
             get_next_token();
@@ -231,6 +238,14 @@ class Parser {
 
           auto function_data = function_storage.find_function(func->name, func->number_args);
           if (function_data.operation == FunctionStorage::Operation::None) {
+            // Try macro lookup before failing
+            auto macro_it = tmpl.macro_storage.find(call_name);
+            if (macro_it != tmpl.macro_storage.end()) {
+              auto macro_call = std::make_shared<MacroCallNode>(call_name, macro_it->second, call_pos);
+              macro_call->arguments = std::move(func->arguments);
+              arguments.emplace_back(macro_call);
+              break;
+            }
             throw_parser_error("unknown function " + func->name);
           }
           func->operation = function_data.operation;
@@ -383,6 +398,13 @@ class Parser {
         // search store for defined function with such name and number of args
         auto function_data = function_storage.find_function(func->name, func->number_args);
         if (function_data.operation == FunctionStorage::Operation::None) {
+          auto macro_it = tmpl.macro_storage.find(func->name);
+          if (macro_it != tmpl.macro_storage.end()) {
+            auto macro_call = std::make_shared<MacroCallNode>(func->name, macro_it->second, func->pos);
+            macro_call->arguments = std::move(func->arguments);
+            arguments.emplace_back(macro_call);
+            break;
+          }
           throw_parser_error("unknown function " + func->name);
         }
         func->operation = function_data.operation;
@@ -559,6 +581,15 @@ class Parser {
       std::string template_name = parse_filename();
       add_to_template_storage(path, template_name);
 
+      // Hoist macros defined in the included template so they can be called
+      // in the including template after this statement.
+      const auto included_it = template_storage.find(template_name);
+      if (included_it != template_storage.end()) {
+        for (const auto& macro_pair : included_it->second.macro_storage) {
+          tmpl.macro_storage.emplace(macro_pair.first, macro_pair.second);
+        }
+      }
+
       current_block->nodes.emplace_back(std::make_shared<IncludeStatementNode>(template_name, tok.text.data() - tmpl.content.c_str()));
 
       get_next_token();
@@ -593,6 +624,75 @@ class Parser {
       if (!parse_expression(tmpl, closing)) {
         return false;
       }
+    } else if (tok.text == static_cast<decltype(tok.text)>("macro")) {
+      get_next_token();
+
+      if (tok.kind != Token::Kind::Id) {
+        throw_parser_error("expected macro name, got '" + tok.describe() + "'");
+      }
+      const std::string macro_name = static_cast<std::string>(tok.text);
+      const size_t macro_pos = tok.text.data() - tmpl.content.c_str();
+      get_next_token();
+
+      if (tok.kind != Token::Kind::LeftParen) {
+        throw_parser_error("expected '(' after macro name, got '" + tok.describe() + "'");
+      }
+      get_next_token();
+
+      auto macro_node = std::make_shared<MacroStatementNode>(current_block, macro_name, macro_pos);
+      if (!current_macro_owner) {
+        current_macro_owner = std::make_shared<Template>(tmpl.content);
+      }
+      macro_node->owner_template = current_macro_owner;
+
+      // Parse parameter list: name1, name2 = expr, name3 ...
+      bool seen_default = false;
+      while (tok.kind != Token::Kind::RightParen) {
+        if (tok.kind != Token::Kind::Id) {
+          throw_parser_error("expected parameter name, got '" + tok.describe() + "'");
+        }
+        MacroParameter param;
+        param.name = static_cast<std::string>(tok.text);
+        get_next_token();
+
+        if (tok.text == static_cast<decltype(tok.text)>("=")) {
+          get_next_token();
+          param.default_value = parse_expression(tmpl);
+          if (!param.default_value) {
+            throw_parser_error("expected expression for default value");
+          }
+          seen_default = true;
+        } else if (seen_default) {
+          throw_parser_error("parameter without default follows parameter with default");
+        }
+
+        macro_node->parameters.emplace_back(std::move(param));
+
+        if (tok.kind == Token::Kind::Comma) {
+          get_next_token();
+        } else if (tok.kind != Token::Kind::RightParen) {
+          throw_parser_error("expected ',' or ')' in parameter list, got '" + tok.describe() + "'");
+        }
+      }
+      get_next_token();
+
+      current_block->nodes.emplace_back(macro_node);
+      auto success = tmpl.macro_storage.emplace(macro_name, macro_node);
+      if (!success.second) {
+        throw_parser_error("macro with the name '" + macro_name + "' does already exist");
+      }
+      macro_statement_stack.emplace(macro_node.get());
+      current_block = &macro_node->body;
+    } else if (tok.text == static_cast<decltype(tok.text)>("endmacro")) {
+      if (macro_statement_stack.empty()) {
+        throw_parser_error("endmacro without matching macro");
+      }
+
+      auto& macro_statement_data = macro_statement_stack.top();
+      get_next_token();
+
+      current_block = macro_statement_data->parent;
+      macro_statement_stack.pop();
     } else {
       return false;
     }
@@ -612,6 +712,9 @@ class Parser {
         }
         if (!for_statement_stack.empty()) {
           throw_parser_error("unmatched for");
+        }
+        if (!macro_statement_stack.empty()) {
+          throw_parser_error("unmatched macro");
         }
       }
         current_block = nullptr;

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -653,6 +653,92 @@ class Renderer : public NodeVisitor {
     additional_data[json::json_pointer(ptr)] = *eval_expression_list(node.expression);
   }
 
+  void visit(const MacroStatementNode&) override {
+    // Macro definitions are registered at parse time; no runtime effect here.
+  }
+
+  void visit(const MacroCallNode& node) override {
+    const auto& macro = *node.macro;
+
+    // 1. Evaluate arguments in the caller's scope and copy values out so that
+    //    swapping additional_data below cannot invalidate pointers.
+    std::vector<json> arg_values;
+    arg_values.reserve(node.arguments.size());
+    for (const auto& arg : node.arguments) {
+      arg->accept(*this);
+      const json* p = data_eval_stack.top();
+      data_eval_stack.pop();
+      if (p) {
+        arg_values.emplace_back(*p);
+      } else {
+        const auto data_node = not_found_stack.top();
+        not_found_stack.pop();
+        throw_renderer_error("variable '" + data_node->name + "' not found", *data_node);
+      }
+    }
+
+    if (arg_values.size() > macro.parameters.size()) {
+      throw_renderer_error("too many arguments for macro '" + macro.name + "'", node);
+    }
+
+    // 2. Save caller context.
+    json saved_additional = std::move(additional_data);
+    json* saved_loop = current_loop_data;
+    auto* saved_template = current_template;
+    auto* saved_stream = output_stream;
+
+    // 3. Create fresh local scope (parameters + input data only).
+    additional_data = json::object();
+    current_loop_data = &additional_data["loop"];
+
+    // 4. Bind parameters: positional args first, defaults for the rest.
+    for (size_t i = 0; i < macro.parameters.size(); ++i) {
+      const auto& param = macro.parameters[i];
+      if (i < arg_values.size()) {
+        additional_data[param.name] = std::move(arg_values[i]);
+      } else if (param.default_value) {
+        param.default_value->accept(*this);
+        const json* p = data_eval_stack.top();
+        data_eval_stack.pop();
+        if (p) {
+          additional_data[param.name] = *p;
+        } else {
+          const auto data_node = not_found_stack.top();
+          not_found_stack.pop();
+          throw_renderer_error("variable '" + data_node->name + "' not found", *data_node);
+        }
+      } else {
+        // Restore before throwing so caller sees a clean state.
+        additional_data = std::move(saved_additional);
+        current_loop_data = saved_loop;
+        throw_renderer_error("missing required argument '" + param.name + "' for macro '" + macro.name + "'", node);
+      }
+    }
+
+    // 5. Switch current_template so TextNode and error locations resolve
+    //    against the source content the macro body references (matters when
+    //    the macro was hoisted from an included template or registered via
+    //    include_template, where the originally parsed Template may be gone).
+    current_template = macro.owner_template.get();
+    template_stack.emplace_back(current_template);
+
+    // 6. Capture body output into a temporary stream.
+    std::ostringstream captured;
+    output_stream = &captured;
+
+    macro.body.accept(*this);
+
+    // 7. Restore.
+    output_stream = saved_stream;
+    template_stack.pop_back();
+    current_template = saved_template;
+    additional_data = std::move(saved_additional);
+    current_loop_data = saved_loop;
+
+    // 8. Push captured output as the call result.
+    make_result(json(captured.str()));
+  }
+
 public:
   explicit Renderer(const RenderConfig& config, const TemplateStorage& template_storage, const FunctionStorage& function_storage)
       : config(config), template_storage(template_storage), function_storage(function_storage) {}

--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -62,6 +62,10 @@ class Renderer : public NodeVisitor {
   const json* data_input;
   std::ostream* output_stream;
 
+  // Nesting depth of in-flight macro calls; guards against runaway recursion (missing base case,
+  // inverted condition, etc.) blowing the C++ call stack. See visit(const MacroCallNode&).
+  size_t macro_call_depth {0};
+
   json additional_data;
   json* current_loop_data = &additional_data["loop"];
 
@@ -658,7 +662,23 @@ class Renderer : public NodeVisitor {
   }
 
   void visit(const MacroCallNode& node) override {
-    const auto& macro = *node.macro;
+    if (macro_call_depth >= config.max_macro_recursion_depth) {
+      throw_renderer_error("macro recursion depth exceeded " + std::to_string(config.max_macro_recursion_depth) + " while calling macro '" + node.name + "'", node);
+    }
+
+    const auto macro_ptr = node.macro.lock();
+    if (!macro_ptr) {
+      throw_renderer_error("macro '" + node.name + "' is no longer available", node);
+    }
+    const auto& macro = *macro_ptr;
+
+    // Counts for the whole body of this function, including argument/default-value evaluation
+    // below (which may itself contain nested macro calls), not just the macro.body.accept() call.
+    ++macro_call_depth;
+    struct DepthGuard {
+      size_t& depth;
+      ~DepthGuard() { --depth; }
+    } depth_guard {macro_call_depth};
 
     // 1. Evaluate arguments in the caller's scope and copy values out so that
     //    swapping additional_data below cannot invalidate pointers.

--- a/include/inja/statistics.hpp
+++ b/include/inja/statistics.hpp
@@ -62,6 +62,14 @@ class StatisticsVisitor : public NodeVisitor {
 
   void visit(const SetStatementNode&) override {}
 
+  void visit(const MacroStatementNode&) override {}
+
+  void visit(const MacroCallNode& node) override {
+    for (const auto& a : node.arguments) {
+      a->accept(*this);
+    }
+  }
+
 public:
   size_t variable_counter {0};
 

--- a/include/inja/template.hpp
+++ b/include/inja/template.hpp
@@ -17,6 +17,8 @@ struct Template {
   BlockNode root;
   std::string content;
   std::map<std::string, std::shared_ptr<BlockStatementNode>> block_storage;
+  // cppcheck-suppress unusedStructMember
+  std::map<std::string, std::shared_ptr<MacroStatementNode>> macro_storage;
 
   explicit Template() {}
   explicit Template(std::string content): content(std::move(content)) {}

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1554,6 +1554,11 @@ class Parser {
   // Created lazily on the first macro definition in the current parse.
   std::shared_ptr<Template> current_macro_owner;
 
+  // Points to the most recently created TextNode, used to detect (without RTTI)
+  // whether a block ends with literal text so a trailing newline can be trimmed
+  // from a macro body.
+  const AstNode* last_text_node {nullptr};
+
   std::stack<IfStatementNode*> if_statement_stack;
   std::stack<ForStatementNode*> for_statement_stack;
   std::stack<BlockStatementNode*> block_statement_stack;
@@ -2197,6 +2202,30 @@ class Parser {
       auto& macro_statement_data = macro_statement_stack.top();
       get_next_token();
 
+      // Trim a single trailing newline from the macro body so a definition such as
+      //   ## macro foo()
+      //   test
+      //   ## endmacro
+      // expands to "test" rather than "test\n" when called. The newline before
+      // 'endmacro' belongs to the source layout, not to the macro's value.
+      auto& body_nodes = macro_statement_data->body.nodes;
+      if (!body_nodes.empty() && body_nodes.back().get() == last_text_node) {
+        auto* const text_node = static_cast<TextNode*>(body_nodes.back().get());
+        const char* const data = tmpl.content.c_str() + text_node->pos;
+        size_t new_length = text_node->length;
+        if (new_length > 0 && data[new_length - 1] == '\n') {
+          new_length -= 1;
+          if (new_length > 0 && data[new_length - 1] == '\r') {
+            new_length -= 1;
+          }
+          if (new_length == 0) {
+            body_nodes.pop_back();
+          } else {
+            body_nodes.back() = std::make_shared<TextNode>(text_node->pos, new_length);
+          }
+        }
+      }
+
       current_block = macro_statement_data->parent;
       macro_statement_stack.pop();
     } else {
@@ -2227,6 +2256,7 @@ class Parser {
         return;
       case Token::Kind::Text: {
         current_block->nodes.emplace_back(std::make_shared<TextNode>(tok.text.data() - tmpl.content.c_str(), tok.text.size()));
+        last_text_node = current_block->nodes.back().get();
       } break;
       case Token::Kind::StatementOpen: {
         get_next_token();

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -772,10 +772,14 @@ class MacroCallNode : public ExpressionNode {
 public:
   const std::string name;
   std::vector<std::shared_ptr<ExpressionNode>> arguments;
-  std::shared_ptr<MacroStatementNode> macro;
+  // Weak: the macro's owning Template (its macro_storage / root BlockNode) already keeps the
+  // MacroStatementNode alive for as long as it can be called. A shared_ptr here would create a
+  // reference cycle for a (self- or mutually-) recursive macro, since its own body contains this
+  // MacroCallNode, which would then keep the MacroStatementNode that owns that body alive forever.
+  std::weak_ptr<MacroStatementNode> macro;
 
-  explicit MacroCallNode(const std::string& name, std::shared_ptr<MacroStatementNode> macro, size_t pos)
-      : ExpressionNode(pos), name(name), macro(std::move(macro)) {}
+  explicit MacroCallNode(const std::string& name, const std::shared_ptr<MacroStatementNode>& macro, size_t pos)
+      : ExpressionNode(pos), name(name), macro(macro) {}
 
   void accept(NodeVisitor& v) const override {
     v.visit(*this);
@@ -970,6 +974,10 @@ struct ParserConfig {
 struct RenderConfig {
   bool throw_at_missing_includes {true};
   bool html_autoescape {false};
+  // Maximum nesting depth of macro calls (a macro calling itself, mutually recursive macros, or
+  // a macro invoked as a default-parameter/argument expression of another macro call all count).
+  // Exceeding it throws inja::RenderError instead of exhausting the C++ call stack.
+  size_t max_macro_recursion_depth {200};
 };
 
 } // namespace inja
@@ -2403,6 +2411,10 @@ class Renderer : public NodeVisitor {
   const json* data_input;
   std::ostream* output_stream;
 
+  // Nesting depth of in-flight macro calls; guards against runaway recursion (missing base case,
+  // inverted condition, etc.) blowing the C++ call stack. See visit(const MacroCallNode&).
+  size_t macro_call_depth {0};
+
   json additional_data;
   json* current_loop_data = &additional_data["loop"];
 
@@ -2999,7 +3011,23 @@ class Renderer : public NodeVisitor {
   }
 
   void visit(const MacroCallNode& node) override {
-    const auto& macro = *node.macro;
+    if (macro_call_depth >= config.max_macro_recursion_depth) {
+      throw_renderer_error("macro recursion depth exceeded " + std::to_string(config.max_macro_recursion_depth) + " while calling macro '" + node.name + "'", node);
+    }
+
+    const auto macro_ptr = node.macro.lock();
+    if (!macro_ptr) {
+      throw_renderer_error("macro '" + node.name + "' is no longer available", node);
+    }
+    const auto& macro = *macro_ptr;
+
+    // Counts for the whole body of this function, including argument/default-value evaluation
+    // below (which may itself contain nested macro calls), not just the macro.body.accept() call.
+    ++macro_call_depth;
+    struct DepthGuard {
+      size_t& depth;
+      ~DepthGuard() { --depth; }
+    } depth_guard {macro_call_depth};
 
     // 1. Evaluate arguments in the caller's scope and copy values out so that
     //    swapping additional_data below cannot invalidate pointers.
@@ -3188,6 +3216,11 @@ public:
   /// Sets whether we'll automatically perform HTML escape
   void set_html_autoescape(bool will_escape) {
     render_config.html_autoescape = will_escape;
+  }
+
+  /// Sets the maximum nesting depth of macro calls before an inja::RenderError is thrown
+  void set_max_macro_recursion_depth(size_t max_depth) {
+    render_config.max_macro_recursion_depth = max_depth;
   }
 
   Template parse(std::string_view input) {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -379,6 +379,8 @@ inline void replace_substring(std::string& s, const std::string& f, const std::s
 
 namespace inja {
 
+struct Template;
+
 class NodeVisitor;
 class BlockNode;
 class TextNode;
@@ -396,6 +398,8 @@ class IncludeStatementNode;
 class ExtendsStatementNode;
 class BlockStatementNode;
 class SetStatementNode;
+class MacroStatementNode;
+class MacroCallNode;
 
 class NodeVisitor {
 public:
@@ -417,6 +421,8 @@ public:
   virtual void visit(const ExtendsStatementNode& node) = 0;
   virtual void visit(const BlockStatementNode& node) = 0;
   virtual void visit(const SetStatementNode& node) = 0;
+  virtual void visit(const MacroStatementNode& node) = 0;
+  virtual void visit(const MacroCallNode& node) = 0;
 };
 
 /*!
@@ -736,6 +742,46 @@ public:
   }
 };
 
+struct MacroParameter {
+  // cppcheck-suppress unusedStructMember
+  std::string name;
+  std::shared_ptr<ExpressionNode> default_value;
+};
+
+class MacroStatementNode : public StatementNode {
+public:
+  const std::string name;
+  // cppcheck-suppress unusedStructMember
+  std::vector<MacroParameter> parameters;
+  // cppcheck-suppress unusedStructMember
+  BlockNode body;
+  BlockNode* const parent;
+  // Holds the source content the macro body references via TextNode offsets.
+  // Stored as shared_ptr so it stays alive even when the originally parsed
+  // Template is copied or destroyed (e.g. when added via include_template).
+  std::shared_ptr<Template> owner_template;
+
+  explicit MacroStatementNode(BlockNode* const parent, const std::string& name, size_t pos): StatementNode(pos), name(name), parent(parent) {}
+
+  void accept(NodeVisitor& v) const override {
+    v.visit(*this);
+  }
+};
+
+class MacroCallNode : public ExpressionNode {
+public:
+  const std::string name;
+  std::vector<std::shared_ptr<ExpressionNode>> arguments;
+  std::shared_ptr<MacroStatementNode> macro;
+
+  explicit MacroCallNode(const std::string& name, std::shared_ptr<MacroStatementNode> macro, size_t pos)
+      : ExpressionNode(pos), name(name), macro(std::move(macro)) {}
+
+  void accept(NodeVisitor& v) const override {
+    v.visit(*this);
+  }
+};
+
 } // namespace inja
 
 #endif // INCLUDE_INJA_NODE_HPP_
@@ -806,6 +852,14 @@ class StatisticsVisitor : public NodeVisitor {
 
   void visit(const SetStatementNode&) override {}
 
+  void visit(const MacroStatementNode&) override {}
+
+  void visit(const MacroCallNode& node) override {
+    for (const auto& a : node.arguments) {
+      a->accept(*this);
+    }
+  }
+
 public:
   size_t variable_counter {0};
 
@@ -826,6 +880,8 @@ struct Template {
   BlockNode root;
   std::string content;
   std::map<std::string, std::shared_ptr<BlockStatementNode>> block_storage;
+  // cppcheck-suppress unusedStructMember
+  std::map<std::string, std::shared_ptr<MacroStatementNode>> macro_storage;
 
   explicit Template() {}
   explicit Template(std::string content): content(std::move(content)) {}
@@ -1494,9 +1550,14 @@ class Parser {
   BlockNode* current_block {nullptr};
   ExpressionListNode* current_expression_list {nullptr};
 
+  // Holds a copy of the current template's content for macros to reference.
+  // Created lazily on the first macro definition in the current parse.
+  std::shared_ptr<Template> current_macro_owner;
+
   std::stack<IfStatementNode*> if_statement_stack;
   std::stack<ForStatementNode*> for_statement_stack;
   std::stack<BlockStatementNode*> block_statement_stack;
+  std::stack<MacroStatementNode*> macro_statement_stack;
 
   void throw_parser_error(const std::string& message) const {
     INJA_THROW(ParserError(message, lexer.current_position()));
@@ -1664,7 +1725,9 @@ class Parser {
 
           // Functions
         } else if (peek_tok.kind == Token::Kind::LeftParen) {
-          auto func = std::make_shared<FunctionNode>(tok.text, tok.text.data() - tmpl.content.c_str());
+          const std::string call_name = static_cast<std::string>(tok.text);
+          const size_t call_pos = tok.text.data() - tmpl.content.c_str();
+          auto func = std::make_shared<FunctionNode>(tok.text, call_pos);
           get_next_token();
           do {
             get_next_token();
@@ -1681,6 +1744,14 @@ class Parser {
 
           auto function_data = function_storage.find_function(func->name, func->number_args);
           if (function_data.operation == FunctionStorage::Operation::None) {
+            // Try macro lookup before failing
+            auto macro_it = tmpl.macro_storage.find(call_name);
+            if (macro_it != tmpl.macro_storage.end()) {
+              auto macro_call = std::make_shared<MacroCallNode>(call_name, macro_it->second, call_pos);
+              macro_call->arguments = std::move(func->arguments);
+              arguments.emplace_back(macro_call);
+              break;
+            }
             throw_parser_error("unknown function " + func->name);
           }
           func->operation = function_data.operation;
@@ -1833,6 +1904,13 @@ class Parser {
         // search store for defined function with such name and number of args
         auto function_data = function_storage.find_function(func->name, func->number_args);
         if (function_data.operation == FunctionStorage::Operation::None) {
+          auto macro_it = tmpl.macro_storage.find(func->name);
+          if (macro_it != tmpl.macro_storage.end()) {
+            auto macro_call = std::make_shared<MacroCallNode>(func->name, macro_it->second, func->pos);
+            macro_call->arguments = std::move(func->arguments);
+            arguments.emplace_back(macro_call);
+            break;
+          }
           throw_parser_error("unknown function " + func->name);
         }
         func->operation = function_data.operation;
@@ -2009,6 +2087,15 @@ class Parser {
       std::string template_name = parse_filename();
       add_to_template_storage(path, template_name);
 
+      // Hoist macros defined in the included template so they can be called
+      // in the including template after this statement.
+      const auto included_it = template_storage.find(template_name);
+      if (included_it != template_storage.end()) {
+        for (const auto& macro_pair : included_it->second.macro_storage) {
+          tmpl.macro_storage.emplace(macro_pair.first, macro_pair.second);
+        }
+      }
+
       current_block->nodes.emplace_back(std::make_shared<IncludeStatementNode>(template_name, tok.text.data() - tmpl.content.c_str()));
 
       get_next_token();
@@ -2043,6 +2130,75 @@ class Parser {
       if (!parse_expression(tmpl, closing)) {
         return false;
       }
+    } else if (tok.text == static_cast<decltype(tok.text)>("macro")) {
+      get_next_token();
+
+      if (tok.kind != Token::Kind::Id) {
+        throw_parser_error("expected macro name, got '" + tok.describe() + "'");
+      }
+      const std::string macro_name = static_cast<std::string>(tok.text);
+      const size_t macro_pos = tok.text.data() - tmpl.content.c_str();
+      get_next_token();
+
+      if (tok.kind != Token::Kind::LeftParen) {
+        throw_parser_error("expected '(' after macro name, got '" + tok.describe() + "'");
+      }
+      get_next_token();
+
+      auto macro_node = std::make_shared<MacroStatementNode>(current_block, macro_name, macro_pos);
+      if (!current_macro_owner) {
+        current_macro_owner = std::make_shared<Template>(tmpl.content);
+      }
+      macro_node->owner_template = current_macro_owner;
+
+      // Parse parameter list: name1, name2 = expr, name3 ...
+      bool seen_default = false;
+      while (tok.kind != Token::Kind::RightParen) {
+        if (tok.kind != Token::Kind::Id) {
+          throw_parser_error("expected parameter name, got '" + tok.describe() + "'");
+        }
+        MacroParameter param;
+        param.name = static_cast<std::string>(tok.text);
+        get_next_token();
+
+        if (tok.text == static_cast<decltype(tok.text)>("=")) {
+          get_next_token();
+          param.default_value = parse_expression(tmpl);
+          if (!param.default_value) {
+            throw_parser_error("expected expression for default value");
+          }
+          seen_default = true;
+        } else if (seen_default) {
+          throw_parser_error("parameter without default follows parameter with default");
+        }
+
+        macro_node->parameters.emplace_back(std::move(param));
+
+        if (tok.kind == Token::Kind::Comma) {
+          get_next_token();
+        } else if (tok.kind != Token::Kind::RightParen) {
+          throw_parser_error("expected ',' or ')' in parameter list, got '" + tok.describe() + "'");
+        }
+      }
+      get_next_token();
+
+      current_block->nodes.emplace_back(macro_node);
+      auto success = tmpl.macro_storage.emplace(macro_name, macro_node);
+      if (!success.second) {
+        throw_parser_error("macro with the name '" + macro_name + "' does already exist");
+      }
+      macro_statement_stack.emplace(macro_node.get());
+      current_block = &macro_node->body;
+    } else if (tok.text == static_cast<decltype(tok.text)>("endmacro")) {
+      if (macro_statement_stack.empty()) {
+        throw_parser_error("endmacro without matching macro");
+      }
+
+      auto& macro_statement_data = macro_statement_stack.top();
+      get_next_token();
+
+      current_block = macro_statement_data->parent;
+      macro_statement_stack.pop();
     } else {
       return false;
     }
@@ -2062,6 +2218,9 @@ class Parser {
         }
         if (!for_statement_stack.empty()) {
           throw_parser_error("unmatched for");
+        }
+        if (!macro_statement_stack.empty()) {
+          throw_parser_error("unmatched macro");
         }
       }
         current_block = nullptr;
@@ -2803,6 +2962,92 @@ class Renderer : public NodeVisitor {
     replace_substring(ptr, ".", "/");
     ptr = "/" + ptr;
     additional_data[json::json_pointer(ptr)] = *eval_expression_list(node.expression);
+  }
+
+  void visit(const MacroStatementNode&) override {
+    // Macro definitions are registered at parse time; no runtime effect here.
+  }
+
+  void visit(const MacroCallNode& node) override {
+    const auto& macro = *node.macro;
+
+    // 1. Evaluate arguments in the caller's scope and copy values out so that
+    //    swapping additional_data below cannot invalidate pointers.
+    std::vector<json> arg_values;
+    arg_values.reserve(node.arguments.size());
+    for (const auto& arg : node.arguments) {
+      arg->accept(*this);
+      const json* p = data_eval_stack.top();
+      data_eval_stack.pop();
+      if (p) {
+        arg_values.emplace_back(*p);
+      } else {
+        const auto data_node = not_found_stack.top();
+        not_found_stack.pop();
+        throw_renderer_error("variable '" + data_node->name + "' not found", *data_node);
+      }
+    }
+
+    if (arg_values.size() > macro.parameters.size()) {
+      throw_renderer_error("too many arguments for macro '" + macro.name + "'", node);
+    }
+
+    // 2. Save caller context.
+    json saved_additional = std::move(additional_data);
+    json* saved_loop = current_loop_data;
+    auto* saved_template = current_template;
+    auto* saved_stream = output_stream;
+
+    // 3. Create fresh local scope (parameters + input data only).
+    additional_data = json::object();
+    current_loop_data = &additional_data["loop"];
+
+    // 4. Bind parameters: positional args first, defaults for the rest.
+    for (size_t i = 0; i < macro.parameters.size(); ++i) {
+      const auto& param = macro.parameters[i];
+      if (i < arg_values.size()) {
+        additional_data[param.name] = std::move(arg_values[i]);
+      } else if (param.default_value) {
+        param.default_value->accept(*this);
+        const json* p = data_eval_stack.top();
+        data_eval_stack.pop();
+        if (p) {
+          additional_data[param.name] = *p;
+        } else {
+          const auto data_node = not_found_stack.top();
+          not_found_stack.pop();
+          throw_renderer_error("variable '" + data_node->name + "' not found", *data_node);
+        }
+      } else {
+        // Restore before throwing so caller sees a clean state.
+        additional_data = std::move(saved_additional);
+        current_loop_data = saved_loop;
+        throw_renderer_error("missing required argument '" + param.name + "' for macro '" + macro.name + "'", node);
+      }
+    }
+
+    // 5. Switch current_template so TextNode and error locations resolve
+    //    against the source content the macro body references (matters when
+    //    the macro was hoisted from an included template or registered via
+    //    include_template, where the originally parsed Template may be gone).
+    current_template = macro.owner_template.get();
+    template_stack.emplace_back(current_template);
+
+    // 6. Capture body output into a temporary stream.
+    std::ostringstream captured;
+    output_stream = &captured;
+
+    macro.body.accept(*this);
+
+    // 7. Restore.
+    output_stream = saved_stream;
+    template_stack.pop_back();
+    current_template = saved_template;
+    additional_data = std::move(saved_additional);
+    current_loop_data = saved_loop;
+
+    // 8. Push captured output as the call result.
+    make_result(json(captured.str()));
   }
 
 public:

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -133,6 +133,39 @@ TEST_CASE("types") {
     CHECK(env.render("{{brother.name}}", data) == "Chris");
   }
 
+  SUBCASE("macros") {
+    CHECK(env.render("{% macro hello(n) %}Hi {{ n }}!{% endmacro %}{{ hello(\"Bob\") }}", data) == "Hi Bob!");
+    CHECK(env.render("{% macro add(a, b) %}{{ a + b }}{% endmacro %}{{ add(2, 3) }}", data) == "5");
+    CHECK(env.render("{% macro greet(n, g=\"Hello\") %}{{ g }}, {{ n }}!{% endmacro %}{{ greet(\"Bob\") }}", data) == "Hello, Bob!");
+    CHECK(env.render("{% macro greet(n, g=\"Hello\") %}{{ g }}, {{ n }}!{% endmacro %}{{ greet(\"Bob\", \"Hey\") }}", data) == "Hey, Bob!");
+    // Input data is visible inside the macro body.
+    CHECK(env.render("{% macro who() %}{{ name }}{% endmacro %}{{ who() }}", data) == "Peter");
+    // Local set variable from outside the macro is NOT visible.
+    CHECK_THROWS_WITH(env.render("{% set x=1 %}{% macro m() %}{{ x }}{% endmacro %}{{ m() }}", data),
+                      doctest::Contains("variable 'x' not found"));
+    // Parameters do not leak out of the macro.
+    CHECK_THROWS_WITH(env.render("{% macro m(x) %}{{ x }}{% endmacro %}{{ m(5) }} {{ x }}", data),
+                      doctest::Contains("variable 'x' not found"));
+    // Macro used inside a for-loop sees the loop value via parameter binding.
+    CHECK(env.render("{% macro li(x) %}<li>{{ x }}</li>{% endmacro %}{% for n in [1,2] %}{{ li(n) }}{% endfor %}", data) ==
+          "<li>1</li><li>2</li>");
+    // Macro calling another macro.
+    CHECK(env.render("{% macro a(x) %}A({{ x }}){% endmacro %}{% macro b(x) %}B[{{ a(x) }}]{% endmacro %}{{ b(\"y\") }}", data) == "B[A(y)]");
+    // Recursive macro.
+    CHECK(env.render("{% macro down(n) %}{% if n > 0 %}{{ n }},{{ down(n - 1) }}{% endif %}{% endmacro %}{{ down(3) }}", data) == "3,2,1,");
+    // Macro defined in an included template.
+    {
+      inja::Environment env2;
+      env2.include_template("macros.tpl", env2.parse("{% macro greet(n) %}Hi {{ n }}{% endmacro %}"));
+      CHECK(env2.render("{% include \"macros.tpl\" %}{{ greet(\"Bob\") }}", data) == "Hi Bob");
+    }
+    // Errors.
+    CHECK_THROWS_WITH(env.render("{% macro m(a, b) %}x{% endmacro %}{{ m(1) }}", data),
+                      doctest::Contains("missing required argument 'b' for macro 'm'"));
+    CHECK_THROWS_WITH(env.parse("{% macro m() %}x"), doctest::Contains("unmatched macro"));
+    CHECK_THROWS_WITH(env.parse("{% endmacro %}"), doctest::Contains("endmacro without matching macro"));
+  }
+
   SUBCASE("short circuit evaluation") {
     CHECK(env.render("{% if 0 and undefined %}do{% else %}nothing{% endif %}", data) == "nothing");
     CHECK_THROWS_WITH(env.render("{% if 1 and undefined %}do{% else %}nothing{% endif %}", data),

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -171,8 +171,25 @@ TEST_CASE("types") {
     // Errors.
     CHECK_THROWS_WITH(env.render("{% macro m(a, b) %}x{% endmacro %}{{ m(1) }}", data),
                       doctest::Contains("missing required argument 'b' for macro 'm'"));
+    CHECK_THROWS_WITH(env.render("{% macro m(a) %}x{% endmacro %}{{ m(1, 2) }}", data),
+                      doctest::Contains("too many arguments for macro 'm'"));
+    CHECK_THROWS_WITH(env.parse("{% macro m() %}x{% endmacro %}{% macro m() %}y{% endmacro %}"),
+                      doctest::Contains("macro with the name 'm' does already exist"));
     CHECK_THROWS_WITH(env.parse("{% macro m() %}x"), doctest::Contains("unmatched macro"));
     CHECK_THROWS_WITH(env.parse("{% endmacro %}"), doctest::Contains("endmacro without matching macro"));
+
+    // Runaway recursion (no base case) throws a RenderError instead of exhausting the C++ stack.
+    CHECK_THROWS_WITH(env.render("{% macro loop(n) %}{{ n }},{{ loop(n + 1) }}{% endmacro %}{{ loop(1) }}", data),
+                      doctest::Contains("macro recursion depth exceeded"));
+
+    // The recursion depth limit is configurable and enforced even for otherwise-legitimate depth.
+    {
+      inja::Environment env3;
+      env3.set_max_macro_recursion_depth(3);
+      CHECK(env3.render("{% macro down(n) %}{% if n > 0 %}{{ n }},{{ down(n - 1) }}{% endif %}{% endmacro %}{{ down(2) }}", data) == "2,1,");
+      CHECK_THROWS_WITH(env3.render("{% macro down(n) %}{% if n > 0 %}{{ n }},{{ down(n - 1) }}{% endif %}{% endmacro %}{{ down(5) }}", data),
+                        doctest::Contains("macro recursion depth exceeded"));
+    }
   }
 
   SUBCASE("short circuit evaluation") {

--- a/test/test-renderer.cpp
+++ b/test/test-renderer.cpp
@@ -159,6 +159,15 @@ TEST_CASE("types") {
       env2.include_template("macros.tpl", env2.parse("{% macro greet(n) %}Hi {{ n }}{% endmacro %}"));
       CHECK(env2.render("{% include \"macros.tpl\" %}{{ greet(\"Bob\") }}", data) == "Hi Bob");
     }
+    // A single trailing newline before endmacro is trimmed so line-statement
+    // style definitions don't introduce an unexpected trailing newline.
+    CHECK(env.render("## macro foo()\ntest\n## endmacro\n[{{ foo() }}]", data) == "[test]");
+    CHECK(env.render("## macro foo()\ntest\r\n## endmacro\n[{{ foo() }}]", data) == "[test]");
+    CHECK(env.render("## macro foo()\na\nb\n## endmacro\n[{{ foo() }}]", data) == "[a\nb]");
+    // Only the final newline is removed.
+    CHECK(env.render("## macro foo()\n\n## endmacro\n[{{ foo() }}]", data) == "[]");
+    // Inline definitions without a trailing newline are unaffected.
+    CHECK(env.render("{% macro foo() %}test{% endmacro %}[{{ foo() }}]", data) == "[test]");
     // Errors.
     CHECK_THROWS_WITH(env.render("{% macro m(a, b) %}x{% endmacro %}{{ m(1) }}", data),
                       doctest::Contains("missing required argument 'b' for macro 'm'"));


### PR DESCRIPTION
This PR adds support for **Jinja2-style macros** — reusable, parameterised template fragments — bringing inja closer to feature-parity with Jinja2 for common templating use cases.

 ```jinja2
 {% macro input(name, value="", type="text") %}
   <input type="{{ type }}" name="{{ name }}" value="{{ value }}"/>
 {% endmacro %}

 {{ input("login") }}
 {{ input("age", "18", "number") }}
```
Features

 - Definition / call: {% macro name(args) %}...{% endmacro %} and {{ name(args) }}.
 - Default parameter values: {% macro greet(name, greeting="Hello") %}...{% endmacro %}.
 - Isolated scope: a macro body sees only its own parameters and the global input data — set variables and loop variables from the caller are not visible (matches Jinja2 semantics). Parameters never leak back
  to the caller.
 - Macros calling macros, including recursion ({% macro foo(n) %}{% if n > 0 %}{{ foo(n - 1) }}{% endif %}{% endmacro %}).
 - Hoisting from {% include %}: macros defined in an included template become callable in the including template after the {% include %} line. This works both for file-system includes and templates registered
  via env.include_template(...).
 - Error handling: missing required argument → inja::RenderError; duplicate macro name / unmatched {% macro %} → inja::ParserError.
 
 Closes #238 