### PR TITLE
fix: return empty string from capitalize on empty input (#337)

### DIFF
--- a/include/inja/renderer.hpp
+++ b/include/inja/renderer.hpp
@@ -344,8 +344,10 @@ class Renderer : public NodeVisitor {
     } break;
     case Op::Capitalize: {
       auto result = get_arguments<1>(node)[0]->get<json::string_t>();
-      result[0] = static_cast<char>(::toupper(result[0]));
-      std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
+      if (!result.empty()) {
+        result[0] = static_cast<char>(::toupper(result[0]));
+        std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
+      }
       make_result(std::move(result));
     } break;
     case Op::Default: {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2496,8 +2496,10 @@ class Renderer : public NodeVisitor {
     } break;
     case Op::Capitalize: {
       auto result = get_arguments<1>(node)[0]->get<json::string_t>();
-      result[0] = static_cast<char>(::toupper(result[0]));
-      std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
+      if (!result.empty()) {
+        result[0] = static_cast<char>(::toupper(result[0]));
+        std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
+      }
       make_result(std::move(result));
     } break;
     case Op::Default: {

--- a/test/test-functions.cpp
+++ b/test/test-functions.cpp
@@ -65,6 +65,7 @@ TEST_CASE("functions") {
   SUBCASE("capitalize") {
     CHECK(env.render("{{ capitalize(name) }}", data) == "Peter");
     CHECK(env.render("{{ capitalize(city) }}", data) == "New york");
+    CHECK(env.render("{{ capitalize(\"\") }}", data) == "");
   }
 
   SUBCASE("range") {


### PR DESCRIPTION
﻿## Summary
Makes `capitalize("")` return an empty string instead of indexing past the end (#337).

## Change
Guard the first-character `toupper` / remaining `tolower` transform behind `!result.empty()`.

## Test
Adds an empty-string case to the capitalize subcase in `test/test-functions.cpp`.

Closes #337
