### PR TITLE
feat: add INJA_VERSION_MAJOR/MINOR/PATCH macros (#341)

### DIFF
--- a/include/inja/inja.hpp
+++ b/include/inja/inja.hpp
@@ -25,6 +25,12 @@ SOFTWARE.
 #ifndef INCLUDE_INJA_INJA_HPP_
 #define INCLUDE_INJA_INJA_HPP_
 
+// Semantic version macros for dependency scanners (#341)
+#define INJA_VERSION_MAJOR 3
+#define INJA_VERSION_MINOR 5
+#define INJA_VERSION_PATCH 0
+
+
 #include "json.hpp"
 #include "throw.hpp"
 #include "environment.hpp"

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -25,6 +25,12 @@ SOFTWARE.
 #ifndef INCLUDE_INJA_INJA_HPP_
 #define INCLUDE_INJA_INJA_HPP_
 
+// Semantic version macros for dependency scanners (#341)
+#define INJA_VERSION_MAJOR 3
+#define INJA_VERSION_MINOR 5
+#define INJA_VERSION_PATCH 0
+
+
 // #include "json.hpp"
 #ifndef INCLUDE_INJA_JSON_HPP_
 #define INCLUDE_INJA_JSON_HPP_
@@ -2496,8 +2502,10 @@ class Renderer : public NodeVisitor {
     } break;
     case Op::Capitalize: {
       auto result = get_arguments<1>(node)[0]->get<json::string_t>();
-      result[0] = static_cast<char>(::toupper(result[0]));
-      std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
+      if (!result.empty()) {
+        result[0] = static_cast<char>(::toupper(result[0]));
+        std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
+      }
       make_result(std::move(result));
     } break;
     case Op::Default: {

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2502,10 +2502,8 @@ class Renderer : public NodeVisitor {
     } break;
     case Op::Capitalize: {
       auto result = get_arguments<1>(node)[0]->get<json::string_t>();
-      if (!result.empty()) {
-        result[0] = static_cast<char>(::toupper(result[0]));
-        std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
-      }
+      result[0] = static_cast<char>(::toupper(result[0]));
+      std::transform(result.begin() + 1, result.end(), result.begin() + 1, [](char c) { return static_cast<char>(::tolower(c)); });
       make_result(std::move(result));
     } break;
     case Op::Default: {


### PR DESCRIPTION
﻿## Summary
Adds preprocessor version macros so tools can detect the Inja version without scraping the ASCII banner (#341).

## Change
In both `include/inja/inja.hpp` and `single_include/inja/inja.hpp`:

```cpp
#define INJA_VERSION_MAJOR 3
#define INJA_VERSION_MINOR 5
#define INJA_VERSION_PATCH 0
```

Values match `project(... VERSION 3.5.0)` in CMakeLists.txt and the header banner.

Closes #341
